### PR TITLE
Rename watch to dev, dev to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ package = fission-cli
 stack_yaml = STACK_YAML="stack.yaml"
 stack = $(stack_yaml) stack
 
-dev:
+build:
 	$(stack) build --fast $(package):lib
 
 release:
@@ -30,7 +30,7 @@ test-ghci:
 bench:
 	$(stack) build --fast --bench $(package)
 
-watch:
+dev:
 	$(stack) exec -- ghcid -c "stack ghci $(package):lib --test --main-is $(package):fission-cli"
 
 setup:

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ There is a `Makefile` filled with helpful commands. The most used in development
 make setup
 
 # Watch project for changes, validating types and syntax
-make watch
+make dev
 ```


### PR DESCRIPTION
# Overview
Simple change suggested by @expede 
Rename the following make commands
- `watch` -> `dev`
- `dev` -> `build`