### PR TITLE
Default path for Up & Watch to curr dir

### DIFF
--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -68,6 +68,7 @@ parseOptions = do
   path <- strArgument $ mconcat
     [ metavar "PATH"
     , help    "The file path of the assets or directory to sync"
+    , value   "./"
     ]
 
   return Up.Options {..}

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -138,6 +138,7 @@ parseOptions = do
   path <- strArgument $ mconcat
     [ metavar "PATH"
     , help    "The file path of the assets or directory to watch"
+    , value   "./"
     ]
 
   return Watch.Options {..}


### PR DESCRIPTION
# Problem
`up` & `watch` require a path. They should default to the current directory if none is given. This was originally implemented but must have been lost in a rewrite

# Solution
Changed `up` and `watch` to default `PATH` metavar to `./`