### PR TITLE
Search recursively up the file tree for auth

### DIFF
--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -34,7 +34,7 @@ whoami :: MonadRIO   cfg m
 whoami =
   Environment.get >>= \case
     Left err -> do
-      logError $ displayShow err
+      logDebug $ displayShow err
       Environment.couldNotRead
 
     Right env -> do

--- a/library/Fission/CLI/Config/Guard.hs
+++ b/library/Fission/CLI/Config/Guard.hs
@@ -57,7 +57,7 @@ ensureLocalConfig handler = do
 
     Left err -> do
       -- We were unable to read the users config
-      logError $ displayShow err
+      logDebug $ displayShow err
       Environment.couldNotRead
       return undefined
 

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -66,9 +66,10 @@ find = do
 findRecurse :: MonadIO m => FilePath -> m (Maybe FilePath)
 findRecurse path = do 
   let filepath = path </> ".fission.yaml"
-  doesFileExist filepath >>= \case
-    True  -> return $ Just filepath
-    False -> case path of
+  exists <- doesFileExist filepath
+  if exists
+    then return $ Just filepath
+    else case path of
       "/" -> return Nothing
       _   -> findRecurse $ takeDirectory path
 

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -47,21 +47,6 @@ init auth = do
       liftIO $ write auth peers
       CLI.Success.putOk "Logged in"
 
--- | Locate auth on the user's system
-find :: MonadIO m => m (Maybe FilePath)
-find = do
-  currDir <- getCurrentDirectory
-  findRecurse currDir
-
-findRecurse :: MonadIO m => FilePath -> m (Maybe FilePath)
-findRecurse "/" = return Nothing
-findRecurse path = do 
-  let filepath = path </> ".fission.yaml"
-  doesFileExist filepath >>= \case
-    True  -> return $ Just filepath
-    False -> findRecurse $ takeDirectory path
-
-
 -- | Retrieve auth from the user's system
 get :: MonadIO m => m (Either SomeException Environment)
 get = find >>= \case 
@@ -77,6 +62,20 @@ get' :: MonadIO m => FilePath -> m (Either SomeException Environment)
 get' path = (liftIO . YAML.decodeFileEither $ path) >>= \case
   Right auth -> return $ Right auth
   Left err -> return . Left $ toException err
+
+-- | Locate auth on the user's system
+find :: MonadIO m => m (Maybe FilePath)
+find = do
+  currDir <- getCurrentDirectory
+  findRecurse currDir
+
+findRecurse :: MonadIO m => FilePath -> m (Maybe FilePath)
+findRecurse "/" = return Nothing
+findRecurse path = do 
+  let filepath = path </> ".fission.yaml"
+  doesFileExist filepath >>= \case
+    True  -> return $ Just filepath
+    False -> findRecurse $ takeDirectory path
 
 -- | Write user's auth to a local on-system path
 write :: MonadUnliftIO m => BasicAuthData -> [IPFS.Peer] -> m ()

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -64,12 +64,13 @@ find = do
   findRecurse currDir
 
 findRecurse :: MonadIO m => FilePath -> m (Maybe FilePath)
-findRecurse "/" = return Nothing
 findRecurse path = do 
   let filepath = path </> ".fission.yaml"
   doesFileExist filepath >>= \case
     True  -> return $ Just filepath
-    False -> findRecurse $ takeDirectory path
+    False -> case path of
+      "/" -> return Nothing
+      _   -> findRecurse $ takeDirectory path
 
 -- | Write user's auth to a local on-system path
 write :: MonadUnliftIO m => BasicAuthData -> [IPFS.Peer] -> m ()

--- a/library/Fission/CLI/Environment/Error.hs
+++ b/library/Fission/CLI/Environment/Error.hs
@@ -2,11 +2,11 @@ module Fission.CLI.Environment.Error (Error(..)) where
 
 import RIO
 
-data Error = NoEnv
+data Error = EnvNotFound
   deriving ( Exception
            , Eq
            , Generic
            )
 
 instance Show Error where
-  show NoEnv = "Could not find .fission.yaml"
+  show EnvNotFound = "Could not find .fission.yaml"

--- a/library/Fission/CLI/Environment/Error.hs
+++ b/library/Fission/CLI/Environment/Error.hs
@@ -1,0 +1,12 @@
+module Fission.CLI.Environment.Error (Error(..)) where
+
+import RIO
+
+data Error = NoEnv
+  deriving ( Exception
+           , Eq
+           , Generic
+           )
+
+instance Show Error where
+  show NoEnv = "Could not find .fission.yaml"


### PR DESCRIPTION
# Summary
## Problem
Today, the `fission.yaml` is global only. You need to sign out and in to the correct account per-project

## Impact
Inconvenient when you have multiple projects that you'd like managed by Fission.

## Solution
Check if the current directory has a fission.yaml. IF it does, use that one. Otherwise look at the parent directory. Recurse until you find one, or hit / and complain.

A couple notes:
- this PR only implements the recursive search for auth. Not exactly sure how we'll handle the UX for login, but it would probably be something like a `--local` flag on `login`/`register` to create an auth file in the current dir instead of home.
- `up`, `watch`, and `whoami` all search recursively for auth. I did not change the implementation of `logout`. This would be simple to do, but I figured since `login` and `register` were scoped to the global level, `logout` should stay that way as well.

Closes https://github.com/fission-suite/cli/issues/23