### PR TITLE
fix some style spelling/styles issues in output

### DIFF
--- a/library/Fission/CLI/Config/Guard.hs
+++ b/library/Fission/CLI/Config/Guard.hs
@@ -51,7 +51,7 @@ ensureLocalConfig handler = do
 
         Left err -> do
           -- We were unable to connect!
-          logError $ displayShow err
+          logDebug $ displayShow err
           Connect.couldNotSwarmConnect
           return undefined
 

--- a/library/Fission/CLI/IPFS/Connect.hs
+++ b/library/Fission/CLI/IPFS/Connect.hs
@@ -44,7 +44,7 @@ swarmConnectWithRetry peer tries = IPFS.Peer.connect peer >>= \case
         return $ Left $ toException UnableToConnect
 
       Right peers -> do
-        UTF8.putText "🛰 Unable to connect to the Fission IPFS peer, trying again..."
+        UTF8.putText "🛰 Unable to connect to the Fission IPFS peer, trying again...\n"
         let peer' = head $ NonEmpty.fromList peers
         swarmConnectWithRetry peer' (tries - 1)
 
@@ -52,9 +52,9 @@ swarmConnectWithRetry peer tries = IPFS.Peer.connect peer >>= \case
 couldNotSwarmConnect :: MonadIO m => m ()
 couldNotSwarmConnect = do
   liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
-  UTF8.putText "😭 We were unable to connect to the Fission IPFS peer!"
+  UTF8.putText "😭 We were unable to connect to the Fission IPFS peer!\n"
 
   liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
-  UTF8.putText "Try checking your connection or logining in again"
+  UTF8.putText "Try checking your connection or logging in again\n"
 
   liftIO $ ANSI.setSGR [ANSI.Reset]


### PR DESCRIPTION
## Problem
Spelling error & some line break issues

## Solution
Fix them :stuck_out_tongue_winking_eye: 

## Question:
Here's the output when not running a node
```
🛰 Unable to connect to the Fission IPFS peer, trying again...
🛰 Unable to connect to the Fission IPFS peer, trying again...
😭 We were unable to connect to the Fission IPFS peer!
Try checking your connection or logging in again
```
Everything gets logged in less than 2s. Makes me think that `🛰 Unable to connect to the Fission IPFS peer, trying again...` is sort of redundant. Thoughts?