### PR TITLE
Update CLI to version 1.21.3

### DIFF
--- a/library/Fission/CLI.hs
+++ b/library/Fission/CLI.hs
@@ -41,7 +41,7 @@ cli = do
     Whoami.command   cfg
   runCLI
   where
-    version     = "1.21.1"
+    version     = "1.21.3"
     description = "CLI to interact with Fission services"
     detail      = mconcat [ "Fission makes developing, deploying, updating "
                           , "and iterating on web applications quick and easy."


### PR DESCRIPTION
**Though shall not release tired!**

We only partially updated our cli to version 1.21.3.

We updated the package file but not the CLI. Thankfully we also mistagged the release as `1.21.23` instead of `1.21.3` so we wont have to worry about an orphaned version number.