### PR TITLE
Remove 2 lines committed accidentally

### DIFF
--- a/.azure/azure-linux-template.yml
+++ b/.azure/azure-linux-template.yml
@@ -36,13 +36,11 @@ jobs:
     - bash: |
         export PATH=$HOME/.local/bin:$PATH
         stack --no-terminal --install-ghc build --copy-bins --local-bin-path $(Build.SourcesDirectory)
-        echo "##vso[task.setvariable variable=thebins] $(stack path --local-bin)"
       displayName: Build Dependencies
 
     - bash: |
         export PATH=$HOME/.local/bin:$PATH
         stack test
-        echo my pipeline variable is $(thebins)
       displayName: Test ${{parameters.os}} Package
 
     - task: ArchiveFiles@2

--- a/.azure/azure-linux-template.yml
+++ b/.azure/azure-linux-template.yml
@@ -34,6 +34,11 @@ jobs:
       displayName: Install Stack
 
     - bash: |
+        sudo apt-get update &&
+        sudo apt-get -y install postgresql libpq-dev
+      displayName: Install postgresql
+
+    - bash: |
         export PATH=$HOME/.local/bin:$PATH
         stack --no-terminal --install-ghc build --copy-bins --local-bin-path $(Build.SourcesDirectory)
       displayName: Build Dependencies

--- a/.azure/azure-osx-template.yml
+++ b/.azure/azure-osx-template.yml
@@ -35,6 +35,10 @@ jobs:
     displayName: Install Stack
 
   - bash: |
+      brew update && brew install postgres
+    displayName: Install Postgres
+
+  - bash: |
       export PATH=$HOME/.local/bin:$PATH
       stack setup --stack-yaml $(STACK_YAML)
       stack --stack-yaml $(STACK_YAML) --install-ghc build --copy-bins --local-bin-path $(Build.SourcesDirectory)


### PR DESCRIPTION

## Summary
I accidentally left two `echo` lines in the yaml that can cause a failed step to be marked successful.

This removes those lines
