### PR TITLE
Use Fission.Prelude

### DIFF
--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Criterion
 import Criterion.Main
-import RIO
+import Fission.Prelude
 
 import qualified Fission.Internal.UTF8 as UTF8
 import qualified RIO.ByteString.Lazy   as Lazy
@@ -14,6 +14,6 @@ main = defaultMain
 
 encode :: [Benchmark]
 encode =
-  [ bench "Strict ByteString" $ whnf UTF8.encode ("hello world" :: ByteString)
-  , bench "Lazy ByteString" $ whnf UTF8.encode ("hello world" :: Lazy.ByteString)
+  [ bench "Strict ByteString" <| whnf UTF8.encode ("hello world" :: ByteString)
+  , bench "Lazy ByteString" <| whnf UTF8.encode ("hello world" :: Lazy.ByteString)
   ]

--- a/library/Fission/CLI.hs
+++ b/library/Fission/CLI.hs
@@ -1,13 +1,9 @@
 module Fission.CLI (cli) where
 
-import           RIO
+import           Fission.Prelude
 import           RIO.Process (HasProcessContext)
 
-import           Data.Has
-
 import           Options.Applicative.Simple
-
-import           Fission.Internal.Constraint
 
 import qualified Fission.Web.Client   as Client
 import qualified Fission.IPFS.Types   as IPFS
@@ -32,7 +28,7 @@ cli :: MonadRIO    cfg m
     => m ()
 cli = do
   cfg <- ask
-  (_, runCLI) <- liftIO $ simpleOptions version description detail (pure ()) do
+  (_, runCLI) <- liftIO <| simpleOptions version description detail (pure ()) do
     Login.command         cfg
     Logout.command        cfg
     Register.command      cfg

--- a/library/Fission/CLI/Command/Down.hs
+++ b/library/Fission/CLI/Command/Down.hs
@@ -1,14 +1,11 @@
 -- | Grab files directly from IPFS
 module Fission.CLI.Command.Down (command, down) where
 
-import           RIO
+import           Fission.Prelude
 import           RIO.Process (HasProcessContext)
 
-import           Data.Has
 import           Options.Applicative.Simple (addCommand)
 import           Options.Applicative (strArgument, metavar, help)
-
-import           Fission.Internal.Constraint
 
 import qualified Fission.Storage.IPFS as IPFS
 import qualified Fission.IPFS.Types   as IPFS
@@ -31,8 +28,8 @@ command cfg =
   addCommand
     "down"
     "Pull a ipfs or ipns object down to your system"
-    (\cid -> runRIO cfg $ down cid)
-    (strArgument $ mconcat
+    (\cid -> runRIO cfg <| down cid)
+    (strArgument <| mconcat
       [ metavar "ContentID"
       , help "The CID of the IPFS object you want to download"
       ])
@@ -47,12 +44,12 @@ down :: MonadUnliftIO         m
      => IPFS.CID
      -> m ()
 down cid@(CID hash) = do
-  getResult <- CLI.Wait.waitFor "Retrieving Object..." $
+  getResult <- CLI.Wait.waitFor "Retrieving Object..." <| 
                 IPFS.getFileOrDirectory cid
 
   case getResult of
     Right _ok ->
-      CLI.Success.putOk $ hash <> " Successfully downloaded!"
+      CLI.Success.putOk <| hash <> " Successfully downloaded!"
 
     Left err ->
       CLI.Error.put err "Oh no! The download failed unexpectedly"

--- a/library/Fission/CLI/Command/Logout.hs
+++ b/library/Fission/CLI/Command/Logout.hs
@@ -1,11 +1,9 @@
 -- | Login command
 module Fission.CLI.Command.Logout (command, logout) where
 
-import           RIO
+import           Fission.Prelude
 
 import           Options.Applicative.Simple (addCommand)
-
-import           Fission.Internal.Constraint
 
 import qualified Fission.CLI.Environment as Environment
 import           Fission.CLI.Config.Types
@@ -22,7 +20,7 @@ command cfg =
   addCommand
     "logout"
     "Logout of your Fission account"
-    (const $ runRIO cfg logout)
+    (const <| runRIO cfg logout)
     (pure ())
 
 -- | Login (i.e. save credentials to disk). Validates credentials agianst the server.

--- a/library/Fission/CLI/Command/Register.hs
+++ b/library/Fission/CLI/Command/Register.hs
@@ -1,11 +1,10 @@
 -- | Register command
 module Fission.CLI.Command.Register (command, register) where
 
-import           RIO
+import           Fission.Prelude
 import           RIO.ByteString
 
 import qualified Data.ByteString.Char8 as BS
-import           Data.Has
 import qualified Data.Text as T
 
 import           Options.Applicative.Simple (addCommand)
@@ -13,7 +12,6 @@ import           Servant
 import           System.Console.Haskeline
 
 import qualified Fission.Config as Config
-import           Fission.Internal.Constraint
 
 import qualified Fission.Web.Client.User  as User.Client
 import qualified Fission.Web.Client.Types as Client
@@ -38,7 +36,7 @@ command cfg =
   addCommand
     "register"
     "Register for Fission and login"
-    (const $ runRIO cfg register)
+    (const <| runRIO cfg register)
     (pure ())
 
 -- | Register and login (i.e. save credentials to disk)
@@ -65,7 +63,7 @@ register' = do
   putStr "Username: "
   username <- getLine
 
-  liftIO (runInputT defaultSettings $ getPassword (Just '•') "Password: ") >>= \case
+  liftIO (runInputT defaultSettings <| getPassword (Just '•') "Password: ") >>= \case
     Nothing ->
       logError "Unable to read password"
 
@@ -81,12 +79,12 @@ register' = do
                       . CLI.Wait.waitFor "Registering..."
                       . runner
                       . User.Client.register
-                      $ User.Registration
+                      <| User.Registration
                           { username = decodeUtf8Lenient username
                           , password = T.pack password
                           , email    = if BS.null rawEmail
                                           then Nothing
-                                          else Just $ decodeUtf8Lenient rawEmail
+                                          else Just <| decodeUtf8Lenient rawEmail
                           }
 
       case registerResult of

--- a/library/Fission/CLI/Command/ResetPassword.hs
+++ b/library/Fission/CLI/Command/ResetPassword.hs
@@ -1,18 +1,16 @@
 -- | Register command
 module Fission.CLI.Command.ResetPassword (command, resetPassword) where
 
-import           RIO
+import           Fission.Prelude
 
 import           Servant
 
-import           Data.Has
 import qualified Data.Text as T
 
 import           Options.Applicative.Simple (addCommand)
 import           System.Console.Haskeline
 
 import qualified Fission.Config as Config
-import           Fission.Internal.Constraint
 import qualified Fission.Internal.UTF8 as UTF8
 
 import qualified Fission.Web.Client.User  as User.Client
@@ -39,7 +37,7 @@ command cfg =
   addCommand
     "reset-password"
     "Reset Fission Password"
-    (const $ void $ runRIO cfg $ LoggedIn.ensure resetPassword)
+    (const <| void <| runRIO cfg <| LoggedIn.ensure resetPassword)
     (pure ())
 
 -- | Register and login (i.e. save credentials to disk)
@@ -49,7 +47,7 @@ resetPassword :: MonadRIO       cfg m
               => m ()
 resetPassword = do
   auth <- Config.get
-  liftIO (runInputT defaultSettings $ getPassword (Just '•') "New Password: ") >>= \case
+  liftIO (runInputT defaultSettings <| getPassword (Just '•') "New Password: ") >>= \case
     Nothing ->
       logError "Unable to read password"
 
@@ -71,7 +69,7 @@ resetPassword' auth newPassword = do
                   . CLI.Wait.waitFor "Registering..."
                   . runner
                   . User.Client.resetPassword auth
-                  $ User.Password $ T.pack newPassword
+                  <| User.Password <| T.pack newPassword
 
   case resetResult of
     Left  err ->
@@ -87,7 +85,7 @@ resetPassword' auth newPassword = do
               , basicAuthPassword = encodeUtf8 updatedPass
               }
           Environment.writeAuth updatedAuth path
-          CLI.Success.putOk $
+          CLI.Success.putOk <|
             "Password reset. Your updated credentials are in " <> UTF8.textShow path
 
 

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -1,14 +1,12 @@
 -- | File sync, IPFS-style
 module Fission.CLI.Command.Up (command, up) where
 
-import           RIO
+import           Fission.Prelude
 import           RIO.Directory
 import           RIO.Process (HasProcessContext)
 
-import           Data.Has
 import           Options.Applicative.Simple hiding (command)
 
-import           Fission.Internal.Constraint
 import           Fission.Internal.Exception
 
 import qualified Fission.Storage.IPFS as IPFS
@@ -35,7 +33,7 @@ command cfg =
   addCommand
     "up"
     "Keep your current working directory up"
-    (\options -> void $ runRIO cfg $ FissionConnected.ensure $ up options)
+    (\options -> void <| runRIO cfg <| FissionConnected.ensure <| up options)
     parseOptions
 
 -- | Sync the current working directory to the server over IPFS
@@ -44,24 +42,24 @@ up :: MonadRIO             cfg m
    => Up.Options
    -> m ()
 up Up.Options {..} = handleWith_ Error.put' do
-  absPath <- liftIO $ makeAbsolute path
-  cid     <- liftE $ IPFS.addDir path
+  absPath <- liftIO <| makeAbsolute path
+  cid     <- liftE <| IPFS.addDir path
 
-  logDebug $ "Starting single IPFS add locally of " <> displayShow absPath
+  logDebug <| "Starting single IPFS add locally of " <> displayShow absPath
 
   unless dnsOnly do
-    void . liftE $ CLI.Pin.run cid
+    void . liftE <| CLI.Pin.run cid
 
-  liftE $ CLI.DNS.update cid
+  liftE <| CLI.DNS.update cid
 
 parseOptions :: Parser Up.Options
 parseOptions = do
-  dnsOnly <- switch $ mconcat
+  dnsOnly <- switch <| mconcat
     [ long "dns-only"
     , help "Only update DNS (skip file sync)"
     ]
 
-  path <- strArgument $ mconcat
+  path <- strArgument <| mconcat
     [ metavar "PATH"
     , help    "The file path of the assets or directory to sync"
     , value   "./"

--- a/library/Fission/CLI/Command/Up/Types.hs
+++ b/library/Fission/CLI/Command/Up/Types.hs
@@ -1,6 +1,6 @@
 module Fission.CLI.Command.Up.Types (Options(..)) where
 
-import RIO
+import Fission.Prelude hiding (Options)
 
 -- | Arguments, flags & switches for the `up` command
 data Options = Options

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -9,7 +9,6 @@ import           Fission.Prelude
 import           RIO.Directory
 import           RIO.Process (HasProcessContext)
 import qualified RIO.Text as Text
-import qualified RIO.Time as Time
 
 import Servant.Client
 
@@ -85,10 +84,10 @@ handleTreeChanges :: HasFissionConnected  cfg
                   -> IO StopListening
 handleTreeChanges timeCache hashCache watchMgr cfg dir =
   FS.watchTree watchMgr dir (const True) \_ -> runRIO cfg do
-    now     <- Time.getCurrentTime
+    now     <- getCurrentTime
     oldTime <- readMVar timeCache
 
-    unless (Time.diffUTCTime now oldTime < Time.doherty) do
+    unless (diffUTCTime now oldTime < Time.doherty) do
       void <| swapMVar timeCache now
       threadDelay Time.dohertyMicroSeconds -- Wait for all events to fire in sliding window
 

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -5,20 +5,17 @@ module Fission.CLI.Command.Watch
   , watcher
   ) where
 
-import           RIO
+import           Fission.Prelude
 import           RIO.Directory
 import           RIO.Process (HasProcessContext)
 import qualified RIO.Text as Text
-import           RIO.Time
-
-import           Data.Has
+import qualified RIO.Time as Time
 
 import Servant.Client
 
 import           Options.Applicative.Simple hiding (command)
 import           System.FSNotify as FS
 
-import           Fission.Internal.Constraint
 import qualified Fission.Internal.UTF8 as UTF8
 
 import qualified Fission.Web.Client   as Client
@@ -53,7 +50,7 @@ command cfg =
   addCommand
     "watch"
     "Keep your working directory in sync with the IPFS network"
-    (\options -> void $ runRIO cfg $ FissionConnected.ensure $ watcher options)
+    (\options -> void <| runRIO cfg <| FissionConnected.ensure <| watcher options)
     parseOptions
 
 -- | Continuously sync the current working directory to the server over IPFS
@@ -64,20 +61,20 @@ watcher :: MonadRIO             cfg m
 watcher Watch.Options {..} = handleWith_ CLI.Error.put' do
   cfg            <- ask
   absPath        <- makeAbsolute path
-  cid@(CID hash) <- liftE $ IPFS.addDir absPath
+  cid@(CID hash) <- liftE <| IPFS.addDir absPath
 
-  UTF8.putText $ "👀 Watching " <> Text.pack absPath <> " for changes...\n"
+  UTF8.putText <| "👀 Watching " <> Text.pack absPath <> " for changes...\n"
 
   when (not dnsOnly) do
-    void . liftE $ CLI.Pin.run cid
+    void . liftE <| CLI.Pin.run cid
 
-  liftE $ CLI.DNS.update cid
+  liftE <| CLI.DNS.update cid
 
-  liftIO $ FS.withManager \watchMgr -> do
+  liftIO <| FS.withManager \watchMgr -> do
     hashCache <- newMVar hash
     timeCache <- newMVar =<< getCurrentTime
-    void $ handleTreeChanges timeCache hashCache watchMgr cfg absPath
-    forever $ liftIO $ threadDelay 1000000 -- Sleep main thread
+    void <| handleTreeChanges timeCache hashCache watchMgr cfg absPath
+    forever <| liftIO <| threadDelay 1000000 -- Sleep main thread
 
 handleTreeChanges :: HasFissionConnected  cfg
                   => MVar UTCTime
@@ -88,11 +85,11 @@ handleTreeChanges :: HasFissionConnected  cfg
                   -> IO StopListening
 handleTreeChanges timeCache hashCache watchMgr cfg dir =
   FS.watchTree watchMgr dir (const True) \_ -> runRIO cfg do
-    now     <- getCurrentTime
+    now     <- Time.getCurrentTime
     oldTime <- readMVar timeCache
 
-    unless (diffUTCTime now oldTime < Time.doherty) do
-      void $ swapMVar timeCache now
+    unless (Time.diffUTCTime now oldTime < Time.doherty) do
+      void <| swapMVar timeCache now
       threadDelay Time.dohertyMicroSeconds -- Wait for all events to fire in sliding window
 
       IPFS.addDir dir >>= \case
@@ -101,11 +98,11 @@ handleTreeChanges timeCache hashCache watchMgr cfg dir =
 
         Right cid@(CID newHash) -> do
           oldHash <- swapMVar hashCache newHash
-          logDebug $ "CID: " <> display oldHash <> " -> " <> display newHash
+          logDebug <| "CID: " <> display oldHash <> " -> " <> display newHash
 
           unless (oldHash == newHash) do
             UTF8.putText "\n"
-            void $ pinAndUpdateDNS cid
+            void <| pinAndUpdateDNS cid
 
 pinAndUpdateDNS :: MonadRIO             cfg m
                 => HasFissionConnected  cfg
@@ -114,20 +111,20 @@ pinAndUpdateDNS :: MonadRIO             cfg m
 pinAndUpdateDNS cid =
   CLI.Pin.run cid >>= \case
     Left err -> do
-      logError $ displayShow err
-      return $ Left err
+      logError <| displayShow err
+      return <| Left err
 
     Right _ ->
       CLI.DNS.update cid
 
 parseOptions :: Parser Watch.Options
 parseOptions = do
-  dnsOnly <- switch $ mconcat
+  dnsOnly <- switch <| mconcat
     [ long "dns-only"
     , help "Only update DNS (i.e. don't actively sync files to the server)"
     ]
 
-  path <- strArgument $ mconcat
+  path <- strArgument <| mconcat
     [ metavar "PATH"
     , help    "The file path of the assets or directory to watch"
     , value   "./"

--- a/library/Fission/CLI/Command/Watch/Types.hs
+++ b/library/Fission/CLI/Command/Watch/Types.hs
@@ -1,6 +1,6 @@
 module Fission.CLI.Command.Watch.Types (Options(..)) where
 
-import RIO
+import Fission.Prelude hiding (Options)
 
 -- | Arguments, flags & switches for the `watch` command
 data Options = Options

--- a/library/Fission/CLI/Command/Whoami.hs
+++ b/library/Fission/CLI/Command/Whoami.hs
@@ -1,7 +1,7 @@
 -- | Whoami command
 module Fission.CLI.Command.Whoami (command, whoami) where
 
-import           RIO
+import           Fission.Prelude
 import           RIO.ByteString
 
 import           Options.Applicative.Simple (addCommand)
@@ -9,7 +9,6 @@ import           Servant
 
 import qualified System.Console.ANSI as ANSI
 
-import           Fission.Internal.Constraint
 import qualified Fission.Internal.UTF8 as UTF8
 
 import qualified Fission.CLI.Environment as Environment
@@ -25,7 +24,7 @@ command cfg =
   addCommand
     "whoami"
     "Check the current user"
-    (const $ runRIO cfg whoami)
+    (const <| runRIO cfg whoami)
     (pure ())
 
 whoami :: MonadRIO   cfg m
@@ -34,13 +33,13 @@ whoami :: MonadRIO   cfg m
 whoami =
   Environment.get >>= \case
     Left err -> do
-      logDebug $ displayShow err
+      logDebug <| displayShow err
       Environment.couldNotRead
 
     Right env -> do
       let auth = userAuth env
       UTF8.putText "💻 Currently logged in as: "
-      liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
-      putStr $ basicAuthUsername auth <> "\n"
+      liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
+      putStr <| basicAuthUsername auth <> "\n"
 
-      liftIO $ ANSI.setSGR [ANSI.Reset]
+      liftIO <| ANSI.setSGR [ANSI.Reset]

--- a/library/Fission/CLI/Config/Base/Types.hs
+++ b/library/Fission/CLI/Config/Base/Types.hs
@@ -8,10 +8,8 @@ module Fission.CLI.Config.Base.Types
   , ipfsTimeout
   ) where
 
-import RIO
-import RIO.Process (ProcessContext, HasProcessContext (..))
+import Fission.Prelude
 
-import Data.Has
 import Control.Lens (makeLenses)
 
 import qualified Fission.Web.Client.Types as Client

--- a/library/Fission/CLI/Config/FissionConnected.hs
+++ b/library/Fission/CLI/Config/FissionConnected.hs
@@ -4,12 +4,8 @@ module Fission.CLI.Config.FissionConnected
   , module Fission.CLI.Config.FissionConnected.Types
   ) where
 
-import           RIO
+import           Fission.Prelude
 import           RIO.Process (ProcessContext, HasProcessContext (..))
-
-import           Data.Has
-
-import           Fission.Internal.Constraint
 
 import qualified Fission.IPFS.Types   as IPFS
 import qualified Fission.Web.Client   as Client
@@ -53,17 +49,17 @@ ensure action = do
       Connect.swarmConnectWithRetry _peer 1 >>= \case
         Right _ -> do
           -- All setup and ready to run!
-          result <- liftIO $ runRIO FissionConnected {..} action
+          result <- liftIO <| runRIO FissionConnected {..} action
           Right <$> return result
 
         Left err -> do
           -- We were unable to connect!
-          logError $ displayShow err
+          logError <| displayShow err
           Connect.couldNotSwarmConnect
-          return $ Left CannotConnect
+          return <| Left CannotConnect
 
     Left err -> do
       -- We were unable to read the users config
-      logDebug $ displayShow err
+      logDebug <| displayShow err
       Environment.couldNotRead
-      return $ Left NotFissionConnected
+      return <| Left NotFissionConnected

--- a/library/Fission/CLI/Config/FissionConnected/Error/Types.hs
+++ b/library/Fission/CLI/Config/FissionConnected/Error/Types.hs
@@ -1,6 +1,6 @@
 module Fission.CLI.Config.FissionConnected.Error.Types (Error (..)) where
 
-import           RIO
+import           Fission.Prelude
 
 data Error
   = NotFissionConnected

--- a/library/Fission/CLI/Config/FissionConnected/Types.hs
+++ b/library/Fission/CLI/Config/FissionConnected/Types.hs
@@ -11,11 +11,9 @@ module Fission.CLI.Config.FissionConnected.Types
   , userAuth
   ) where
 
-import RIO
-import RIO.Process (ProcessContext, HasProcessContext (..))
+import Fission.Prelude
 import Servant.API
 
-import Data.Has
 import Control.Lens (makeLenses)
 
 import qualified Fission.Web.Client.Types as Client

--- a/library/Fission/CLI/Config/LoggedIn.hs
+++ b/library/Fission/CLI/Config/LoggedIn.hs
@@ -4,11 +4,7 @@ module Fission.CLI.Config.LoggedIn
   , module Fission.CLI.Config.LoggedIn.Types
   ) where
 
-import           RIO
-
-import           Data.Has
-
-import           Fission.Internal.Constraint
+import           Fission.Prelude
 
 import qualified Fission.Web.Client   as Client
 
@@ -40,11 +36,11 @@ ensure action = do
       let
         _userAuth = Environment.userAuth config
       -- All setup and logged in!
-      result <- liftIO $ runRIO LoggedIn {..} action
+      result <- liftIO <| runRIO LoggedIn {..} action
       Right <$> return result
 
     Left err -> do
       -- We were unable to read the users config
-      logDebug $ displayShow err
+      logDebug <| displayShow err
       Environment.couldNotRead
-      return $ Left NotLoggedIn
+      return <| Left NotLoggedIn

--- a/library/Fission/CLI/Config/LoggedIn/Error/Types.hs
+++ b/library/Fission/CLI/Config/LoggedIn/Error/Types.hs
@@ -1,6 +1,6 @@
 module Fission.CLI.Config.LoggedIn.Error.Types (Error (..)) where
 
-import           RIO
+import           Fission.Prelude
 
 data Error = NotLoggedIn
   deriving (Eq, Show, Exception)

--- a/library/Fission/CLI/Config/LoggedIn/Types.hs
+++ b/library/Fission/CLI/Config/LoggedIn/Types.hs
@@ -7,10 +7,9 @@ module Fission.CLI.Config.LoggedIn.Types
   , userAuth
   ) where
 
-import RIO
+import Fission.Prelude
 import Servant.API
 
-import Data.Has
 import Control.Lens (makeLenses)
 
 import qualified Fission.Web.Client.Types as Client

--- a/library/Fission/CLI/DNS.hs
+++ b/library/Fission/CLI/DNS.hs
@@ -1,16 +1,12 @@
 -- | Update DNS via the CLI
 module Fission.CLI.DNS (update) where
 
-import RIO
-
-import Data.Has
+import Fission.Prelude
 
 import Servant
 import Servant.Client
 
 import qualified Fission.Config as Config
-import           Fission.Internal.Constraint
-
 import           Fission.IPFS.CID.Types
 
 import qualified Fission.Web.Client      as Client
@@ -30,17 +26,17 @@ update :: MonadRIO       cfg m
     -> m (Either ClientError AWS.DomainName)
 update cid@(CID hash) = do
   auth <- Config.get
-  logDebug $ "Updating DNS to " <> display hash
+  logDebug <| "Updating DNS to " <> display hash
 
   Client.Runner runner <- Config.get
   update' runner auth cid >>= \case
     Right domain -> do
-      CLI.Success.dnsUpdated $ AWS.getDomainName domain
-      return $ Right domain
+      CLI.Success.dnsUpdated <| AWS.getDomainName domain
+      return <| Right domain
 
     Left err -> do
       CLI.Error.put' err
-      return $ Left err
+      return <| Left err
 
 update' :: MonadIO m
         => (ClientM AWS.DomainName -> IO a)
@@ -50,4 +46,4 @@ update' :: MonadIO m
 update' runner auth cid =
   liftIO . CLI.withLoader 50000
          . runner
-         $ DNS.Client.update auth cid
+         <| DNS.Client.update auth cid

--- a/library/Fission/CLI/Display/Cursor.hs
+++ b/library/Fission/CLI/Display/Cursor.hs
@@ -1,7 +1,7 @@
 -- | Helpers for working with a cursor in a console
 module Fission.CLI.Display.Cursor (withHidden) where
 
-import RIO
+import Fission.Prelude
 
 import qualified System.Console.ANSI as ANSI
 

--- a/library/Fission/CLI/Display/Error.hs
+++ b/library/Fission/CLI/Display/Error.hs
@@ -1,24 +1,23 @@
 -- | File sync, IPFS-style
 module Fission.CLI.Display.Error (put, put') where
 
-import           RIO
+import           Fission.Prelude
 
 import qualified System.Console.ANSI as ANSI
 
-import           Fission.Internal.Constraint
 import qualified Fission.Internal.UTF8 as UTF8
 
 -- | Display a given error to the user and log an error to the debug log.
 put :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> Text -> m ()
 put err msg = do
-  logDebug $ displayShow err
-  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
-  UTF8.putText $ "🚫 " <> msg <> "\n"
-  liftIO $ ANSI.setSGR [ANSI.Reset]
+  logDebug <| displayShow err
+  liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
+  UTF8.putText <| "🚫 " <> msg <> "\n"
+  liftIO <| ANSI.setSGR [ANSI.Reset]
 
 -- | Display a generic error message to the user and log an error to the debug log.
 put' :: (MonadRIO cfg m, HasLogFunc cfg, Show err) => err -> m ()
-put' err = put err $ mconcat
+put' err = put err <| mconcat
   [ "Something went wrong. Please try again or file a bug report with "
   , "Fission support at https://github.com/fission-suite/web-api/issues/new"
   ]

--- a/library/Fission/CLI/Display/Success.hs
+++ b/library/Fission/CLI/Display/Success.hs
@@ -5,7 +5,7 @@ module Fission.CLI.Display.Success
   , dnsUpdated
   ) where
 
-import RIO
+import Fission.Prelude
 
 import qualified System.Console.ANSI as ANSI
 
@@ -13,16 +13,16 @@ import qualified Fission.Internal.UTF8 as UTF8
 
 live :: MonadIO m => Text -> m ()
 live hash = do
-  UTF8.putText $ "🚀 Now live on the network\n"
-  UTF8.putText $ "👌 " <> hash  <> "\n"
+  UTF8.putText <| "🚀 Now live on the network\n"
+  UTF8.putText <| "👌 " <> hash  <> "\n"
 
 putOk :: MonadIO m => Text -> m ()
 putOk msg = do
-  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green]
-  UTF8.putText $ "✅ " <> msg <> "\n"
-  liftIO $ ANSI.setSGR [ANSI.Reset]
+  liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green]
+  UTF8.putText <| "✅ " <> msg <> "\n"
+  liftIO <| ANSI.setSGR [ANSI.Reset]
 
 dnsUpdated :: MonadIO m => Text -> m ()
 dnsUpdated domain = do
   UTF8.putText "📝 DNS updated! Check out your site at: \n"
-  UTF8.putText $ "🔗 " <> domain  <> "\n"
+  UTF8.putText <| "🔗 " <> domain  <> "\n"

--- a/library/Fission/CLI/Display/Wait.hs
+++ b/library/Fission/CLI/Display/Wait.hs
@@ -1,7 +1,7 @@
 -- | Wait for an action on the CLI
 module Fission.CLI.Display.Wait (waitFor) where
 
-import RIO
+import Fission.Prelude
 import RIO.ByteString
 
 import qualified System.Console.ANSI as ANSI
@@ -10,10 +10,10 @@ import Fission.CLI.Display.Loader
 
 waitFor :: MonadUnliftIO m => ByteString -> m a -> m a
 waitFor msg action = do
-  liftIO $ ANSI.cursorForward 3
-  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Yellow]
+  liftIO <| ANSI.cursorForward 3
+  liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Yellow]
   putStr msg
-  liftIO $ ANSI.setCursorColumn 0
+  liftIO <| ANSI.setCursorColumn 0
   result <- withLoader 5000 action
-  liftIO $ ANSI.setSGR [ANSI.Reset]
+  liftIO <| ANSI.setSGR [ANSI.Reset]
   return result

--- a/library/Fission/CLI/Environment/Error.hs
+++ b/library/Fission/CLI/Environment/Error.hs
@@ -1,6 +1,6 @@
 module Fission.CLI.Environment.Error (Env(..)) where
 
-import RIO
+import Fission.Prelude
 
 data Env = EnvNotFound | EnvIncomplete
   deriving ( Exception

--- a/library/Fission/CLI/Environment/Partial.hs
+++ b/library/Fission/CLI/Environment/Partial.hs
@@ -8,13 +8,13 @@ module Fission.CLI.Environment.Partial
   , updatePeers
   ) where
 
-import           RIO           hiding (set)
+import           Fission.Prelude hiding (decode)
 import           RIO.Directory
 import           RIO.File
 import           RIO.FilePath
 
 import qualified Data.Yaml as YAML
-import           Data.List.NonEmpty as NonEmpty
+import           Data.List.NonEmpty as NonEmpty hiding ((<|))
 
 import           Fission.CLI.Environment.Types
 import           Fission.CLI.Environment.Partial.Types as Env
@@ -29,34 +29,34 @@ get :: MonadIO m => m Env.Partial
 get = recurseEnv =<< getCurrentDirectory
 
 recurseEnv :: MonadIO m => FilePath -> m Env.Partial
-recurseEnv "/" = decode $ "/.fission.yaml"
+recurseEnv "/" = decode <| "/.fission.yaml"
 recurseEnv path = do
-  parent <- recurseEnv $ takeDirectory path
-  curr <- decode $ path </> ".fission.yaml"
-  return $ parent <> curr
+  parent <- recurseEnv <| takeDirectory path
+  curr <- decode <| path </> ".fission.yaml"
+  return <| parent <> curr
 
 -- | Decodes file to partial environment
 decode :: MonadIO m => FilePath -> m Env.Partial
-decode path = liftIO $ YAML.decodeFileEither path >>= \case
-  Left _ -> return $ mempty Env.Partial
+decode path = liftIO <| YAML.decodeFileEither path >>= \case
+  Left _ -> return <| mempty Env.Partial
   Right env -> return env
 
 -- | Writes partial environment to path
 write :: MonadIO m => FilePath -> Env.Partial -> m ()
-write path env = writeBinaryFileDurable path $ YAML.encode env
+write path env = writeBinaryFileDurable path <| YAML.encode env
 
 toFull :: Env.Partial -> (Either Error.Env Environment)
 toFull partial =
   case maybeUserAuth partial of
     Nothing -> Left Error.EnvIncomplete
-    Just basicAuth -> Right $ Environment
+    Just basicAuth -> Right <| Environment
       { userAuth = basicAuth
       , peers = maybePeers partial
       }
 
 fromFull :: Environment -> Env.Partial
 fromFull env = Env.Partial
-  { maybeUserAuth = Just $ userAuth env
+  { maybeUserAuth = Just <| userAuth env
   , maybePeers = peers env
   }
 

--- a/library/Fission/CLI/Environment/Partial/Types.hs
+++ b/library/Fission/CLI/Environment/Partial/Types.hs
@@ -1,8 +1,7 @@
 module Fission.CLI.Environment.Partial.Types ( Partial (..)) where
 
-import RIO
+import Fission.Prelude
 
-import           Data.Aeson
 import           Servant.API
 
 import qualified Fission.IPFS.Types as IPFS
@@ -14,13 +13,13 @@ data Partial = Partial
   } 
 
 instance ToJSON Partial where
-  toJSON Partial {..} = object $ catMaybes
+  toJSON Partial {..} = object <| catMaybes
     [ ("user_auth" .=) <$> maybeUserAuth
     , ("peers" .=) <$> maybePeers
     ]
 
 instance FromJSON Partial where
-  parseJSON = withObject "Partial" $ \obj ->
+  parseJSON = withObject "Partial" <| \obj ->
     Partial <$> obj .:? "user_auth"
             <*> obj .:? "peers"
 

--- a/library/Fission/CLI/Environment/Types.hs
+++ b/library/Fission/CLI/Environment/Types.hs
@@ -1,8 +1,7 @@
 module Fission.CLI.Environment.Types (Environment (..)) where
 
-import RIO
+import Fission.Prelude
 
-import           Data.Aeson
 import           Servant.API
 
 import qualified Fission.IPFS.Types as IPFS
@@ -20,6 +19,6 @@ instance ToJSON Environment where
     ]
 
 instance FromJSON Environment where
-  parseJSON = withObject "Environment" $ \obj ->
+  parseJSON = withObject "Environment" <| \obj ->
     Environment <$> obj .: "user_auth"
                 <*> obj .: "peers"

--- a/library/Fission/CLI/IPFS/Connect.hs
+++ b/library/Fission/CLI/IPFS/Connect.hs
@@ -4,15 +4,11 @@ module Fission.CLI.IPFS.Connect
   , couldNotSwarmConnect
   ) where
 
-import           RIO           hiding (set)
+import           Fission.Prelude
 import           RIO.Process (HasProcessContext)
 
 import qualified System.Console.ANSI as ANSI
-
-import           Data.Has
-import           Data.List.NonEmpty as NonEmpty
-
-import           Fission.Internal.Constraint
+import           Data.List.NonEmpty as NonEmpty hiding ((<|))
 
 import           Fission.Web.Client.Peers as Peers
 import qualified Fission.Web.Client.Types as Client
@@ -36,28 +32,28 @@ swarmConnectWithRetry :: MonadRIO cfg m
           => IPFS.Peer
           -> Int
           -> m (Either SomeException ())
-swarmConnectWithRetry _peer (-1) = return $ Left $ toException UnableToConnect
+swarmConnectWithRetry _peer (-1) = return <| Left <| toException UnableToConnect
 swarmConnectWithRetry peer tries = IPFS.Peer.connect peer >>= \case
   Right _ ->
-    return $ Right ()
+    return <| Right ()
 
   Left _err ->
     Peers.getPeers >>= \case
       Left _ ->
-        return $ Left $ toException UnableToConnect
+        return <| Left <| toException UnableToConnect
 
       Right peers -> do
         UTF8.putText "🛰 Unable to connect to the Fission IPFS peer, trying again...\n"
-        let peer' = head $ NonEmpty.fromList peers
+        let peer' = head <| NonEmpty.fromList peers
         swarmConnectWithRetry peer' (tries - 1)
 
 -- | Create a could not connect to Fission peer message for the terminal
 couldNotSwarmConnect :: MonadIO m => m ()
 couldNotSwarmConnect = do
-  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
+  liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red]
   UTF8.putText "😭 We were unable to connect to the Fission IPFS peer!\n"
 
-  liftIO $ ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
+  liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
   UTF8.putText "Try checking your connection or logging in again\n"
 
-  liftIO $ ANSI.setSGR [ANSI.Reset]
+  liftIO <| ANSI.setSGR [ANSI.Reset]

--- a/library/Fission/CLI/IPFS/Error/Types.hs
+++ b/library/Fission/CLI/IPFS/Error/Types.hs
@@ -1,6 +1,6 @@
 module Fission.CLI.IPFS.Error.Types (Err (..)) where
 
-import           RIO
+import           Fission.Prelude
 
 data Err = UnableToConnect
   deriving (Show, Exception)

--- a/library/Fission/CLI/IPFS/Pin.hs
+++ b/library/Fission/CLI/IPFS/Pin.hs
@@ -4,13 +4,12 @@ module Fission.CLI.IPFS.Pin
   , run
   ) where
 
-import RIO
+import Fission.Prelude
 
 import Servant
 import Servant.Client
 
 import qualified Fission.Config as Config
-import           Fission.Internal.Constraint
 
 import           Fission.IPFS.CID.Types
 
@@ -29,7 +28,7 @@ run
   => CID
   -> m (Either ClientError CID)
 run cid@(CID hash)  = do
-  logDebug $ "Remote pinning " <> display hash
+  logDebug <| "Remote pinning " <> display hash
 
   Client.Runner runner <- Config.get
   auth <- Config.get
@@ -37,11 +36,11 @@ run cid@(CID hash)  = do
   liftIO (pin runner auth cid) >>= \case
     Right _ -> do
       CLI.Success.live hash
-      return $ Right cid
+      return <| Right cid
 
     Left err -> do
       CLI.Error.put' err
-      return $ Left err
+      return <| Left err
 
 pin :: MonadUnliftIO m => (ClientM NoContent -> m a) -> BasicAuthData -> CID -> m a
-pin runner auth cid = CLI.withLoader 50000 . runner $ Fission.pin (Fission.request auth) cid
+pin runner auth cid = CLI.withLoader 50000 . runner <| Fission.pin (Fission.request auth) cid

--- a/library/Fission/Web/Client.hs
+++ b/library/Fission/Web/Client.hs
@@ -4,7 +4,7 @@ module Fission.Web.Client
   , module Fission.Web.Client.Types
   ) where
 
-import RIO
+import Fission.Prelude
 
 import qualified Network.HTTP.Client as HTTP
 import           Servant
@@ -19,4 +19,4 @@ withAuth :: HasClient ClientM api
 withAuth basicAuth proxy = client proxy basicAuth
 
 request :: HTTP.Manager -> BaseUrl -> ClientM a -> IO (Either ClientError a)
-request manager url query = runClientM query $ mkClientEnv manager url
+request manager url query = runClientM query <| mkClientEnv manager url

--- a/library/Fission/Web/Client/IPFS.hs
+++ b/library/Fission/Web/Client/IPFS.hs
@@ -5,7 +5,7 @@ module Fission.Web.Client.IPFS
   , request
   ) where
 
-import RIO
+import Fission.Prelude
 
 import Servant
 import Servant.Client

--- a/library/Fission/Web/Client/Peers.hs
+++ b/library/Fission/Web/Client/Peers.hs
@@ -1,11 +1,10 @@
 -- | Servant client for retrieving peer data
 module Fission.Web.Client.Peers (getPeers) where
 
-import RIO
+import Fission.Prelude
 
 import Servant
 import Servant.Client
-import Data.Has
 
 import qualified Fission.Web.IPFS.Peer as Peer
 import qualified Fission.Web.Client.Types as Client
@@ -28,10 +27,10 @@ getPeers :: MonadReader cfg m
 getPeers = do
   Client.Runner run <- Config.get
   liftIO
-    $ Cursor.withHidden
-    $ CLI.Wait.waitFor "Retrieving Fission Peer List..."
-    $ run
-    $ get
+    <| Cursor.withHidden
+    <| CLI.Wait.waitFor "Retrieving Fission Peer List..."
+    <| run
+    <| get
 
 -- | Retrieve a list of peers from the fission api
 get :: ClientM [IPFS.Peer]

--- a/library/Fission/Web/Client/Register.hs
+++ b/library/Fission/Web/Client/Register.hs
@@ -4,7 +4,7 @@ module Fission.Web.Client.Register
   , reset
   ) where
 
-import           RIO
+import           Fission.Prelude
 
 import           Servant
 import           Servant.Client

--- a/library/Fission/Web/Client/Types.hs
+++ b/library/Fission/Web/Client/Types.hs
@@ -1,6 +1,6 @@
 module Fission.Web.Client.Types (Runner (..)) where
 
-import RIO
+import Fission.Prelude
 
 import Servant.Client
 

--- a/library/Fission/Web/Client/User.hs
+++ b/library/Fission/Web/Client/User.hs
@@ -4,7 +4,7 @@ module Fission.Web.Client.User
   , verify
   ) where
 
-import RIO
+import Fission.Prelude
 
 import Servant
 import Servant.Client
@@ -24,4 +24,4 @@ resetPassword' :: BasicAuthData -> User.Password.Reset -> ClientM (User.Password
 register :<|> verify :<|> resetPassword' = client (Proxy :: Proxy UserRoute)
 
 resetPassword :: BasicAuthData -> User.Password -> ClientM (User.Password)
-resetPassword auth pw = resetPassword' auth $ User.Password.Reset $ Just pw
+resetPassword auth pw = resetPassword' auth <| User.Password.Reset <| Just pw

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
 - raven-haskell-0.1.2.1
 - tasty-rerun-1.1.14
 - git: https://github.com/fission-suite/web-api.git
-  commit: 5664764f5467000894b3d746905c8f77dbc96a52
+  commit: 417f88192fd5b19033000d9ca71602345ec498a2
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
 - raven-haskell-0.1.2.1
 - tasty-rerun-1.1.14
 - git: https://github.com/fission-suite/web-api.git
-  commit: cd9a74b225254dbd2a7d7dd8be6aa6ba423d5df9
+  commit: 5664764f5467000894b3d746905c8f77dbc96a52
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -84,10 +84,10 @@ packages:
     pantry-tree:
       size: 11411
       sha256: 6f7ee8c3fcedd1956fa7634beced0b94049dcbafdaa93f51fae485080f83ae7e
-    commit: 5664764f5467000894b3d746905c8f77dbc96a52
+    commit: 417f88192fd5b19033000d9ca71602345ec498a2
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: 5664764f5467000894b3d746905c8f77dbc96a52
+    commit: 417f88192fd5b19033000d9ca71602345ec498a2
 snapshots:
 - completed:
     size: 524127

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -83,11 +83,11 @@ packages:
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
       size: 11411
-      sha256: bf74c55d60c848da798f223527475686969fed94a57e93995556cd290e26c498
-    commit: cd9a74b225254dbd2a7d7dd8be6aa6ba423d5df9
+      sha256: 6f7ee8c3fcedd1956fa7634beced0b94049dcbafdaa93f51fae485080f83ae7e
+    commit: 5664764f5467000894b3d746905c8f77dbc96a52
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: cd9a74b225254dbd2a7d7dd8be6aa6ba423d5df9
+    commit: 5664764f5467000894b3d746905c8f77dbc96a52
 snapshots:
 - completed:
     size: 524127

--- a/test/coverage-code/Main.hs
+++ b/test/coverage-code/Main.hs
@@ -2,7 +2,7 @@
 
 module Main (main) where
 
-import           RIO
+import           Fission.Prelude
 import qualified RIO.Partial as Part
 import           RIO.Process
 
@@ -15,10 +15,10 @@ main :: IO ()
 main = runSimpleApp do
   output <- proc "hpc" ["report", "dist/hpc/tix/hspec/hspec.tix"] readProcessStdout_
 
-  if average (match $ show output) >= expected
+  if average (match <| show output) >= expected
     then liftIO exitSuccess
     else do
-      logWarn $ displayShow output
+      logWarn <| displayShow output
       liftIO exitFailure
 
 match :: String -> [Int]

--- a/test/coverage-docs/Main.hs
+++ b/test/coverage-docs/Main.hs
@@ -2,7 +2,7 @@
 
 module Main (main) where
 
-import           RIO
+import           Fission.Prelude
 import qualified RIO.Partial as Part
 import           RIO.Process
 
@@ -15,17 +15,17 @@ main :: IO ()
 main = runSimpleApp do
   output <- proc "cabal" ["new-haddock"] readProcessStdout_
 
-  if average (match $ show output) >= expected
+  if average (match <| show output) >= expected
     then liftIO exitSuccess
     else do
-      logWarn $ displayShow output
+      logWarn <| displayShow output
       liftIO exitFailure
 
 match :: String -> [Int]
 match = fmap Part.read
       . concat
       . catMaybes
-      . fmap (matchRegex $ mkRegex "^ *([0-9]*)% ")
+      . fmap (matchRegex <| mkRegex "^ *([0-9]*)% ")
       . lines
 
 average :: (Fractional a, Real b) => [b] -> a

--- a/test/doctest/Main.hs
+++ b/test/doctest/Main.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import           RIO
+import           Fission.Prelude
 import qualified RIO.List as List
 
 import Data.Aeson.Lens
@@ -39,7 +39,7 @@ setup tmp src = do
     go :: FilePath -> ByteString -> DirTree ByteString -> IO ()
     go dirPath exts' = \case
       Failed { err } ->
-        error $ show err
+        error <| show err
 
       Dir { name, contents } -> do
         let path = dirPath <> "/" <> name
@@ -52,7 +52,7 @@ setup tmp src = do
 header :: [ByteString] -> ByteString
 header raw = mconcat
   [ "{-# LANGUAGE "
-  , mconcat $ List.intersperse ", " raw
+  , mconcat <| List.intersperse ", " raw
   , " #-}\n"
   ]
 
@@ -60,7 +60,7 @@ getExts :: IO [ByteString]
 getExts = do
   pkg <- decodeFileThrow "package.yaml" :: IO Value
   let exts = pkg ^. key "default-extensions" . _Array
-  return $ extract <$> toList exts
+  return <| extract <$> toList exts
   where
     extract (String txt) = encodeUtf8 txt
     extract _            = error "Malformed package.yaml"

--- a/test/lint/Main.hs
+++ b/test/lint/Main.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import RIO
+import Fission.Prelude
 
 import Language.Haskell.HLint (hlint)
 

--- a/test/testsuite/Main.hs
+++ b/test/testsuite/Main.hs
@@ -4,7 +4,7 @@
 
 module Main (main) where
 
-import RIO
+import Fission.Prelude
 
 import Test.Tasty                   (TestTree, defaultMainWithIngredients, testGroup)
 import Test.Tasty.HUnit             (Assertion, testCase, (@?=))
@@ -33,11 +33,11 @@ import Test.Tasty.SmallCheck        (testProperty)
 --   --                     }
 
 --   putStrLn "Testing..."
---   hspec . spec . run port . logger $ app config
+--   hspec . spec . run port . logger <| app config
 
 -- spec :: IO () -> Spec
 -- spec server = with server do
---   describe "GET /ping" $ do
+--   describe "GET /ping" <| do
 --     it "responds with 200" do
 --       1 `shouldBe` 1
 --       -- get "/users" `shouldRespondWith` 200


### PR DESCRIPTION
## Problem
CLI still manually imports packages & uses operators like `$`. 

## Solution
Switch out `import RIO` for `import Fission.Prelude` and update other imports & operators accordingly.