### PR TITLE
Ignore files

### DIFF
--- a/library/Fission/CLI/Command/Down.hs
+++ b/library/Fission/CLI/Command/Down.hs
@@ -7,8 +7,8 @@ import           RIO.Process (HasProcessContext)
 import           Options.Applicative.Simple (addCommand)
 import           Options.Applicative (strArgument, metavar, help)
 
-import qualified Fission.Storage.IPFS as IPFS
-import qualified Fission.IPFS.Types   as IPFS
+import qualified Fission.Storage.IPFS.Get as IPFS
+import qualified Fission.IPFS.Types       as IPFS
 import           Fission.IPFS.CID.Types
 import           Fission.CLI.Config.Types
 

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -9,16 +9,18 @@ import           Options.Applicative.Simple hiding (command)
 
 import           Fission.Internal.Exception
 
-import qualified Fission.Storage.IPFS as IPFS
-import qualified Fission.IPFS.Types   as IPFS
-import qualified Fission.Web.Client   as Client
+import qualified Fission.Storage.IPFS.Add as IPFS
+import qualified Fission.IPFS.Types       as IPFS
+import qualified Fission.Web.Client       as Client
 
 import           Fission.CLI.Command.Up.Types as Up
 import qualified Fission.CLI.Display.Error    as Error
 import qualified Fission.CLI.IPFS.Pin         as CLI.Pin
 import qualified Fission.CLI.DNS              as CLI.DNS
+
 import           Fission.CLI.Config.Types
 import           Fission.CLI.Config.FissionConnected  as FissionConnected
+import qualified Fission.Config           as Config
 
 -- | The command to attach to the CLI tree
 command :: MonadIO m
@@ -42,8 +44,9 @@ up :: MonadRIO             cfg m
    => Up.Options
    -> m ()
 up Up.Options {..} = handleWith_ Error.put' do
+  ignoredFiles :: IPFS.Ignored <- Config.get
   absPath <- liftIO <| makeAbsolute path
-  cid     <- liftE <| IPFS.addDir path
+  cid     <- liftE <| IPFS.addDir ignoredFiles path
 
   logDebug <| "Starting single IPFS add locally of " <> displayShow absPath
 

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -9,10 +9,6 @@ import           Fission.Prelude
 import           RIO.Directory
 import           RIO.Process (HasProcessContext)
 import qualified RIO.Text as Text
-<<<<<<< HEAD
-=======
-import qualified RIO.Time as Time
->>>>>>> use Fission.Prelude
 
 import Servant.Client
 
@@ -88,7 +84,7 @@ handleTreeChanges :: HasFissionConnected  cfg
                   -> IO StopListening
 handleTreeChanges timeCache hashCache watchMgr cfg dir =
   FS.watchTree watchMgr dir (const True) \_ -> runRIO cfg do
-    now     <- Time.getCurrentTime
+    now     <- getCurrentTime
     oldTime <- readMVar timeCache
 
     unless (diffUTCTime now oldTime < Time.doherty) do

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -9,6 +9,10 @@ import           Fission.Prelude
 import           RIO.Directory
 import           RIO.Process (HasProcessContext)
 import qualified RIO.Text as Text
+<<<<<<< HEAD
+=======
+import qualified RIO.Time as Time
+>>>>>>> use Fission.Prelude
 
 import Servant.Client
 
@@ -84,7 +88,7 @@ handleTreeChanges :: HasFissionConnected  cfg
                   -> IO StopListening
 handleTreeChanges timeCache hashCache watchMgr cfg dir =
   FS.watchTree watchMgr dir (const True) \_ -> runRIO cfg do
-    now     <- getCurrentTime
+    now     <- Time.getCurrentTime
     oldTime <- readMVar timeCache
 
     unless (diffUTCTime now oldTime < Time.doherty) do

--- a/library/Fission/CLI/Config/FissionConnected.hs
+++ b/library/Fission/CLI/Config/FissionConnected.hs
@@ -44,6 +44,7 @@ ensure action = do
     Right config -> do
       _peer         <- Environment.getOrRetrievePeer config
       let _userAuth = Environment.userAuth config
+      let _ignoredFiles = Environment.ignored config
 
       -- Connect the local IPFS node to the Fission network
       Connect.swarmConnectWithRetry _peer 1 >>= \case

--- a/library/Fission/CLI/Config/FissionConnected/Types.hs
+++ b/library/Fission/CLI/Config/FissionConnected/Types.hs
@@ -19,6 +19,7 @@ import Control.Lens (makeLenses)
 import qualified Fission.Web.Client.Types as Client
 import qualified Fission.IPFS.Types       as IPFS
 
+
 type HasFissionConnected cfg
   = ( HasLogFunc        cfg
     , HasProcessContext cfg
@@ -27,16 +28,18 @@ type HasFissionConnected cfg
     , Has IPFS.BinPath  cfg
     , Has IPFS.Peer     cfg
     , Has BasicAuthData cfg
+    , Has IPFS.Ignored  cfg
     )
 
 data FissionConnected = FissionConnected
-  { _fissionAPI  :: !Client.Runner
-  , _logFunc     :: !LogFunc
-  , _processCtx  :: !ProcessContext
-  , _ipfsPath    :: !IPFS.BinPath
-  , _ipfsTimeout :: !IPFS.Timeout
-  , _peer        :: !IPFS.Peer
-  , _userAuth    :: !BasicAuthData
+  { _fissionAPI   :: !Client.Runner
+  , _logFunc      :: !LogFunc
+  , _processCtx   :: !ProcessContext
+  , _ipfsPath     :: !IPFS.BinPath
+  , _ipfsTimeout  :: !IPFS.Timeout
+  , _peer         :: !IPFS.Peer
+  , _ignoredFiles :: !IPFS.Ignored
+  , _userAuth     :: !BasicAuthData
   }
 
 makeLenses ''FissionConnected
@@ -59,5 +62,9 @@ instance Has IPFS.Timeout FissionConnected where
 instance Has IPFS.Peer FissionConnected where
   hasLens = peer
 
+instance Has IPFS.Ignored FissionConnected where
+  hasLens = ignoredFiles
+
 instance Has BasicAuthData FissionConnected where
   hasLens = userAuth
+

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -49,10 +49,12 @@ init auth = do
       CLI.Error.put err "Peer retrieval failed"
 
     Right peers -> do
-      let env = Env.Partial {
-        maybeUserAuth = Just auth,
-        maybePeers = Just (NonEmpty.fromList peers)
-      }
+      let
+        env = Env.Partial
+          { maybeUserAuth = Just auth
+          , maybePeers = Just (NonEmpty.fromList peers)
+          , maybeIgnored = Just []
+          }
       liftIO <| Env.Partial.write path env
       CLI.Success.putOk "Logged in"
 

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -14,6 +14,7 @@ import           RIO.Directory
 import           RIO.FilePath
 import           Servant.API
 
+import qualified System.FilePath.Glob as Glob
 import qualified System.Console.ANSI as ANSI
 import           Data.List.NonEmpty  as NonEmpty hiding (init, (<|))
 
@@ -53,7 +54,7 @@ init auth = do
         env = Env.Partial
           { maybeUserAuth = Just auth
           , maybePeers = Just (NonEmpty.fromList peers)
-          , maybeIgnored = Just []
+          , maybeIgnored = Just ignoreDefault
           }
       liftIO <| Env.Partial.write path env
       CLI.Success.putOk "Logged in"
@@ -140,3 +141,6 @@ getOrRetrievePeer config =
           path <- globalEnv
           write path <| config { peers = Just (NonEmpty.fromList peers) }
           return <| head <| NonEmpty.fromList peers
+
+ignoreDefault :: IPFS.Ignored
+ignoreDefault = [Glob.compile ".fission.yaml"] 

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -143,4 +143,8 @@ getOrRetrievePeer config =
           return <| head <| NonEmpty.fromList peers
 
 ignoreDefault :: IPFS.Ignored
-ignoreDefault = [Glob.compile ".fission.yaml"] 
+ignoreDefault =
+  [ Glob.compile ".fission.yaml"
+  , Glob.compile ".env"
+  , Glob.compile ".DS_Store"
+  ]

--- a/library/Fission/CLI/Environment/Partial.hs
+++ b/library/Fission/CLI/Environment/Partial.hs
@@ -52,16 +52,19 @@ toFull partial =
     Just basicAuth -> Right <| Environment
       { userAuth = basicAuth
       , peers = maybePeers partial
+      , ignored = fromMaybe [] <| maybeIgnored partial
       }
 
 fromFull :: Environment -> Env.Partial
 fromFull env = Env.Partial
   { maybeUserAuth = Just <| userAuth env
   , maybePeers = peers env
+  , maybeIgnored = Just <| ignored env
   }
 
 updatePeers :: Env.Partial -> [IPFS.Peer] -> Env.Partial
 updatePeers env peers = Env.Partial
   { maybeUserAuth = maybeUserAuth env
   , maybePeers = Just (NonEmpty.fromList peers)
+  , maybeIgnored = maybeIgnored env
   }

--- a/library/Fission/CLI/Environment/Partial/Types.hs
+++ b/library/Fission/CLI/Environment/Partial/Types.hs
@@ -6,33 +6,39 @@ import           Servant.API
 
 import qualified Fission.IPFS.Types as IPFS
 import           Fission.Internal.Orphanage.BasicAuthData ()
-                
+import           Fission.Internal.Orphanage.Glob.Pattern ()
+
 data Partial = Partial
   { maybeUserAuth :: Maybe BasicAuthData
   , maybePeers    :: Maybe (NonEmpty IPFS.Peer)
+  , maybeIgnored  :: Maybe (IPFS.Ignored)
   } 
 
 instance ToJSON Partial where
   toJSON Partial {..} = object <| catMaybes
     [ ("user_auth" .=) <$> maybeUserAuth
     , ("peers" .=) <$> maybePeers
+    , ("ignore" .=) <$> maybeIgnored
     ]
 
 instance FromJSON Partial where
   parseJSON = withObject "Partial" <| \obj ->
     Partial <$> obj .:? "user_auth"
             <*> obj .:? "peers"
+            <*> obj .:? "ignore"
 
 instance Semigroup Partial where
-  a <> b = Partial {
-    maybeUserAuth = getField maybeUserAuth a b,
-    maybePeers = getField maybePeers a b
-  }
+  a <> b = Partial
+    { maybeUserAuth = getField maybeUserAuth a b
+    , maybePeers = getField maybePeers a b
+    , maybeIgnored = getField maybeIgnored a b
+    }
 
 instance Monoid Partial where
   mempty = Partial
     { maybeUserAuth = Nothing
     , maybePeers = Nothing
+    , maybeIgnored = Nothing
     }
 
 getField :: (Partial -> Maybe field) -> Partial -> Partial -> Maybe field

--- a/library/Fission/CLI/Environment/Partial/Types.hs
+++ b/library/Fission/CLI/Environment/Partial/Types.hs
@@ -1,4 +1,4 @@
-module Fission.CLI.Environment.Partial.Types ( Partial (..)) where
+module Fission.CLI.Environment.Partial.Types (Partial (..)) where
 
 import Fission.Prelude
 

--- a/library/Fission/CLI/Environment/Types.hs
+++ b/library/Fission/CLI/Environment/Types.hs
@@ -6,19 +6,23 @@ import           Servant.API
 
 import qualified Fission.IPFS.Types as IPFS
 import           Fission.Internal.Orphanage.BasicAuthData ()
+import           Fission.Internal.Orphanage.Glob.Pattern ()
 
 data Environment = Environment
   { userAuth :: BasicAuthData
   , peers    :: Maybe (NonEmpty IPFS.Peer)
+  , ignored  :: IPFS.Ignored
   }
 
 instance ToJSON Environment where
   toJSON Environment {..} = object
     [ "user_auth" .= userAuth
     , "peers"     .= peers
+    , "ignore"    .= ignored
     ]
 
 instance FromJSON Environment where
   parseJSON = withObject "Environment" <| \obj ->
     Environment <$> obj .: "user_auth"
                 <*> obj .: "peers"
+                <*> obj .: "ignore"

--- a/package.yaml
+++ b/package.yaml
@@ -88,6 +88,7 @@ dependencies:
   - filepath
   - fission-web-api
   - fsnotify
+  - Glob
   - haskeline
   - http-client
   - http-client-tls

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
 - raven-haskell-0.1.2.1
 - tasty-rerun-1.1.14
 - git: https://github.com/fission-suite/web-api.git
-  commit: 159b87a92d6140b9bed577f0a89f80d17eeb09fd
+  commit: ce4df3b37e63bd37a979221e52b8c334c105c27a
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
 - raven-haskell-0.1.2.1
 - tasty-rerun-1.1.14
 - git: https://github.com/fission-suite/web-api.git
-  commit: 4be947613d59b74b9724e16cb2b6a51a076d36be
+  commit: 159b87a92d6140b9bed577f0a89f80d17eeb09fd
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
 - raven-haskell-0.1.2.1
 - tasty-rerun-1.1.14
 - git: https://github.com/fission-suite/web-api.git
-  commit: 417f88192fd5b19033000d9ca71602345ec498a2
+  commit: 4be947613d59b74b9724e16cb2b6a51a076d36be
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -76,18 +76,18 @@ packages:
     hackage: tasty-rerun-1.1.14
 - completed:
     cabal-file:
-      size: 21269
-      sha256: f476edc8f126070f200bf0eb2d7372950d44bcd3d05b56bef146021b392f34d6
+      size: 21870
+      sha256: cabe00c1ebf4f7297584fab7a2e26062f9418979c77622fe8df12ba4bb42ddc9
     name: fission-web-api
     version: 2.0.0
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
-      size: 11411
-      sha256: 6f7ee8c3fcedd1956fa7634beced0b94049dcbafdaa93f51fae485080f83ae7e
-    commit: 417f88192fd5b19033000d9ca71602345ec498a2
+      size: 11955
+      sha256: fab3092b10da027554d17c697c9da71eed98b09bd4ddeedeb369af4e8a9e6497
+    commit: 4be947613d59b74b9724e16cb2b6a51a076d36be
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: 417f88192fd5b19033000d9ca71602345ec498a2
+    commit: 4be947613d59b74b9724e16cb2b6a51a076d36be
 snapshots:
 - completed:
     size: 524127

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -83,11 +83,11 @@ packages:
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
       size: 11955
-      sha256: fab3092b10da027554d17c697c9da71eed98b09bd4ddeedeb369af4e8a9e6497
-    commit: 4be947613d59b74b9724e16cb2b6a51a076d36be
+      sha256: 6faa498ee820f04f74bcb9f8759af10b7540e43722249fab4f8d565535fa53ba
+    commit: 159b87a92d6140b9bed577f0a89f80d17eeb09fd
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: 4be947613d59b74b9724e16cb2b6a51a076d36be
+    commit: 159b87a92d6140b9bed577f0a89f80d17eeb09fd
 snapshots:
 - completed:
     size: 524127

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -83,11 +83,11 @@ packages:
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
       size: 11955
-      sha256: 6faa498ee820f04f74bcb9f8759af10b7540e43722249fab4f8d565535fa53ba
-    commit: 159b87a92d6140b9bed577f0a89f80d17eeb09fd
+      sha256: 9eebddd7ab7de52786b8bc2cf3013dddc9b724ef30cc520df72dbd0ff2defc32
+    commit: ce4df3b37e63bd37a979221e52b8c334c105c27a
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: 159b87a92d6140b9bed577f0a89f80d17eeb09fd
+    commit: ce4df3b37e63bd37a979221e52b8c334c105c27a
 snapshots:
 - completed:
     size: 524127


### PR DESCRIPTION
## Problem
`up` and `watch` upload the entire directory

## Impact
Files that you don't want shared (for instance, .env or .Ds_Store can end up being uploaded to IPFS.

## Solution
Add an `ignore` option to `.fission.yaml` that takes an array of file globs to ignore.

Closes https://github.com/fission-suite/cli/issues/31