### PR TITLE
Add a project-aware build-dir

### DIFF
--- a/library/Fission/CLI/Command/ResetPassword.hs
+++ b/library/Fission/CLI/Command/ResetPassword.hs
@@ -25,7 +25,10 @@ import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Wait    as CLI.Wait
-import qualified Fission.CLI.Environment     as Environment
+
+import qualified Fission.CLI.Environment               as Environment
+import qualified Fission.CLI.Environment.Partial       as Env.Partial
+import           Fission.CLI.Environment.Partial.Types as Env
 
 -- | The command to attach to the CLI tree
 command :: MonadUnliftIO m
@@ -84,7 +87,8 @@ resetPassword' auth newPassword = do
               { basicAuthUsername = basicAuthUsername auth
               , basicAuthPassword = encodeUtf8 updatedPass
               }
-          Environment.writeAuth updatedAuth path
+            updatedEnv = (mempty Env.Partial) { maybeUserAuth = Just updatedAuth}
+          Env.Partial.writeMerge path updatedEnv
           CLI.Success.putOk <|
             "Password reset. Your updated credentials are in " <> UTF8.textShow path
 

--- a/library/Fission/CLI/Command/Up.hs
+++ b/library/Fission/CLI/Command/Up.hs
@@ -15,6 +15,7 @@ import qualified Fission.Web.Client       as Client
 
 import           Fission.CLI.Command.Up.Types as Up
 import qualified Fission.CLI.Display.Error    as Error
+import qualified Fission.CLI.Prompt.BuildDir  as Prompt
 import qualified Fission.CLI.IPFS.Pin         as CLI.Pin
 import qualified Fission.CLI.DNS              as CLI.DNS
 
@@ -45,10 +46,12 @@ up :: MonadRIO             cfg m
    -> m ()
 up Up.Options {..} = handleWith_ Error.put' do
   ignoredFiles :: IPFS.Ignored <- Config.get
-  absPath <- liftIO <| makeAbsolute path
-  cid     <- liftE <| IPFS.addDir ignoredFiles path
 
+  toAdd <- Prompt.checkBuildDir path
+  absPath <- liftIO <| makeAbsolute toAdd
   logDebug <| "Starting single IPFS add locally of " <> displayShow absPath
+          
+  cid     <- liftE <| IPFS.addDir ignoredFiles path
 
   unless dnsOnly do
     void . liftE <| CLI.Pin.run cid

--- a/library/Fission/CLI/Command/Watch.hs
+++ b/library/Fission/CLI/Command/Watch.hs
@@ -31,6 +31,7 @@ import           Fission.CLI.Display.Error as CLI.Error
 import qualified Fission.CLI.Config.FissionConnected as FissionConnected
 
 import           Fission.CLI.Command.Watch.Types as Watch
+import qualified Fission.CLI.Prompt.BuildDir  as Prompt
 import           Fission.CLI.Config.Types
 import qualified Fission.CLI.IPFS.Pin            as CLI.Pin
 import qualified Fission.CLI.DNS                 as CLI.DNS
@@ -61,8 +62,12 @@ watcher :: MonadRIO             cfg m
         -> m ()
 watcher Watch.Options {..} = handleWith_ CLI.Error.put' do
   cfg            <- ask
-  absPath        <- makeAbsolute path
   ignoredFiles :: IPFS.Ignored <- Config.get
+
+  toAdd <- Prompt.checkBuildDir path
+  absPath        <- makeAbsolute toAdd
+  logDebug <| "Starting single IPFS add locally of " <> displayShow absPath
+
   cid@(CID hash) <- liftE <| IPFS.addDir ignoredFiles absPath
 
   UTF8.putText <| "👀 Watching " <> Text.pack absPath <> " for changes...\n"

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -4,7 +4,6 @@ module Fission.CLI.Environment
   , get
   , findLocalAuth
   , findRecurse
-  , writeAuth
   , couldNotRead
   , removeConfigFile
   , getOrRetrievePeer

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -61,12 +61,13 @@ init auth = do
       liftIO <| Env.Partial.write path env
       CLI.Success.putOk "Logged in"
 
--- | Gets hierarchical environment by recursed through file system
+-- | Gets hierarchical environment by recursing through file system
 get :: MonadIO m => m (Either Error.Env Environment)
 get = do 
   partial <- Env.Partial.get
   return <| Env.Partial.toFull partial
 
+-- | Writes env to path, overwriting if necessary
 write :: MonadIO m => FilePath -> Environment -> m ()
 write path env = Env.Partial.write path <| Env.Partial.fromFull env
 
@@ -78,6 +79,7 @@ findLocalAuth = do
     Nothing -> return <| Left Error.EnvNotFound 
     Just (path, _) -> return <| Right path
 
+-- | Recurses up to user root to find a env that satisfies function "f"
 findRecurse :: MonadIO m => (Env.Partial -> Bool) -> FilePath -> m (Maybe (FilePath, Env.Partial))
 findRecurse f path = do 
   let filepath = path </> ".fission.yaml"
@@ -92,14 +94,6 @@ globalEnv :: MonadIO m => m FilePath
 globalEnv = do
   home <- getHomeDirectory
   return <| home </> ".fission.yaml"
-
-writeAuth :: MonadRIO cfg m
-          => BasicAuthData
-          -> FilePath
-          -> m ()
-writeAuth auth path = do
-  partial <- Env.Partial.decode path
-  Env.Partial.write path <| partial { maybeUserAuth = Just auth }
 
 -- | Create a could not read message for the terminal
 couldNotRead :: MonadIO m => m ()

--- a/library/Fission/CLI/Environment/Partial.hs
+++ b/library/Fission/CLI/Environment/Partial.hs
@@ -1,8 +1,8 @@
 module Fission.CLI.Environment.Partial
   ( get
-  , recurseEnv
   , decode
   , write
+  , writeMerge
   , toFull
   , fromFull
   , updatePeers
@@ -26,12 +26,12 @@ import qualified Fission.IPFS.Types as IPFS
 
 -- | Gets hierarchical environment by recursed through file system
 get :: MonadIO m => m Env.Partial
-get = recurseEnv =<< getCurrentDirectory
+get = getRecurse =<< getCurrentDirectory
 
-recurseEnv :: MonadIO m => FilePath -> m Env.Partial
-recurseEnv "/" = decode <| "/.fission.yaml"
-recurseEnv path = do
-  parent <- recurseEnv <| takeDirectory path
+getRecurse :: MonadIO m => FilePath -> m Env.Partial
+getRecurse "/" = decode <| "/.fission.yaml"
+getRecurse path = do
+  parent <- getRecurse <| takeDirectory path
   curr <- decode <| path </> ".fission.yaml"
   return <| parent <> curr
 
@@ -45,6 +45,11 @@ decode path = liftIO <| YAML.decodeFileEither path >>= \case
 write :: MonadIO m => FilePath -> Env.Partial -> m ()
 write path env = writeBinaryFileDurable path <| YAML.encode env
 
+writeMerge :: MonadIO m => FilePath -> Env.Partial -> m ()
+writeMerge path newEnv = do
+  currEnv <- decode path
+  writeBinaryFileDurable path <| YAML.encode <| currEnv <> newEnv
+
 toFull :: Env.Partial -> (Either Error.Env Environment)
 toFull partial =
   case maybeUserAuth partial of
@@ -53,6 +58,7 @@ toFull partial =
       { userAuth = basicAuth
       , peers = maybePeers partial
       , ignored = fromMaybe [] <| maybeIgnored partial
+      , buildDir = maybeBuildDir partial
       }
 
 fromFull :: Environment -> Env.Partial
@@ -60,11 +66,9 @@ fromFull env = Env.Partial
   { maybeUserAuth = Just <| userAuth env
   , maybePeers = peers env
   , maybeIgnored = Just <| ignored env
+  , maybeBuildDir = buildDir env
   }
 
 updatePeers :: Env.Partial -> [IPFS.Peer] -> Env.Partial
-updatePeers env peers = Env.Partial
-  { maybeUserAuth = maybeUserAuth env
-  , maybePeers = Just (NonEmpty.fromList peers)
-  , maybeIgnored = maybeIgnored env
-  }
+updatePeers env peers = env
+  { maybePeers    = Just (NonEmpty.fromList peers) }

--- a/library/Fission/CLI/Environment/Partial.hs
+++ b/library/Fission/CLI/Environment/Partial.hs
@@ -45,6 +45,7 @@ decode path = liftIO <| YAML.decodeFileEither path >>= \case
 write :: MonadIO m => FilePath -> Env.Partial -> m ()
 write path env = writeBinaryFileDurable path <| YAML.encode env
 
+-- | Merges partial env with the env at the path and overwrites
 writeMerge :: MonadIO m => FilePath -> Env.Partial -> m ()
 writeMerge path newEnv = do
   currEnv <- decode path

--- a/library/Fission/CLI/Environment/Partial/Types.hs
+++ b/library/Fission/CLI/Environment/Partial/Types.hs
@@ -12,13 +12,15 @@ data Partial = Partial
   { maybeUserAuth :: Maybe BasicAuthData
   , maybePeers    :: Maybe (NonEmpty IPFS.Peer)
   , maybeIgnored  :: Maybe (IPFS.Ignored)
+  , maybeBuildDir :: Maybe (FilePath)
   } 
 
 instance ToJSON Partial where
   toJSON Partial {..} = object <| catMaybes
     [ ("user_auth" .=) <$> maybeUserAuth
-    , ("peers" .=) <$> maybePeers
-    , ("ignore" .=) <$> maybeIgnored
+    , ("peers" .=)     <$> maybePeers
+    , ("ignore" .=)    <$> maybeIgnored
+    , ("build_dir" .=) <$> maybeBuildDir
     ]
 
 instance FromJSON Partial where
@@ -26,12 +28,14 @@ instance FromJSON Partial where
     Partial <$> obj .:? "user_auth"
             <*> obj .:? "peers"
             <*> obj .:? "ignore"
+            <*> obj .:? "build_dir"
 
 instance Semigroup Partial where
   a <> b = Partial
     { maybeUserAuth = getField maybeUserAuth a b
-    , maybePeers = getField maybePeers a b
-    , maybeIgnored = getField maybeIgnored a b
+    , maybePeers    = getField maybePeers a b
+    , maybeIgnored  = getField maybeIgnored a b
+    , maybeBuildDir = getField maybeBuildDir a b
     }
 
 instance Monoid Partial where
@@ -39,6 +43,7 @@ instance Monoid Partial where
     { maybeUserAuth = Nothing
     , maybePeers = Nothing
     , maybeIgnored = Nothing
+    , maybeBuildDir = Nothing
     }
 
 getField :: (Partial -> Maybe field) -> Partial -> Partial -> Maybe field

--- a/library/Fission/CLI/Environment/Types.hs
+++ b/library/Fission/CLI/Environment/Types.hs
@@ -12,6 +12,7 @@ data Environment = Environment
   { userAuth :: BasicAuthData
   , peers    :: Maybe (NonEmpty IPFS.Peer)
   , ignored  :: IPFS.Ignored
+  , buildDir :: Maybe (FilePath)
   }
 
 instance ToJSON Environment where
@@ -19,6 +20,7 @@ instance ToJSON Environment where
     [ "user_auth" .= userAuth
     , "peers"     .= peers
     , "ignore"    .= ignored
+    , "build_dir" .= buildDir
     ]
 
 instance FromJSON Environment where
@@ -26,3 +28,4 @@ instance FromJSON Environment where
     Environment <$> obj .: "user_auth"
                 <*> obj .: "peers"
                 <*> obj .: "ignore"
+                <*> obj .: "build_dir"

--- a/library/Fission/CLI/Prompt.hs
+++ b/library/Fission/CLI/Prompt.hs
@@ -8,6 +8,7 @@ import           RIO.ByteString as BS hiding (map, pack)
 import qualified Fission.Internal.UTF8 as UTF8
 import qualified Data.List as L
 
+-- | Continues prompting the user until they put in a valid response
 reask :: 
   ( MonadIO m )
   => Text
@@ -20,6 +21,7 @@ reask prompt check = do
     then return resp
     else reask prompt check
 
+-- | reask where valid responses are some form of yes/no
 reaskYN ::
   ( MonadIO m )
   => Text

--- a/library/Fission/CLI/Prompt.hs
+++ b/library/Fission/CLI/Prompt.hs
@@ -1,0 +1,37 @@
+module Fission.CLI.Prompt
+  ( reask
+  , reaskYN
+  ) where
+
+import           Fission.Prelude
+import           RIO.ByteString as BS hiding (map, pack)
+import qualified Fission.Internal.UTF8 as UTF8
+import qualified Data.List as L
+
+reask :: 
+  ( MonadIO m )
+  => Text
+  -> (ByteString -> Bool)
+  -> m ByteString
+reask prompt check = do
+  UTF8.putText prompt
+  resp <- getLine
+  if check resp
+    then return resp
+    else reask prompt check
+
+reaskYN ::
+  ( MonadIO m )
+  => Text
+  -> m Bool
+reaskYN prompt = reask prompt ynTest
+  >>= return . isYes
+
+ynTest :: ByteString -> Bool
+ynTest resp = isYes resp || isNo resp
+
+isYes :: ByteString -> Bool
+isYes resp = L.elem resp (["y", "Y", "yes", "Yes"] :: [ByteString])
+
+isNo :: ByteString -> Bool
+isNo resp = L.elem resp (["n", "N", "no", "No"] :: [ByteString])

--- a/library/Fission/CLI/Prompt/BuildDir.hs
+++ b/library/Fission/CLI/Prompt/BuildDir.hs
@@ -68,15 +68,16 @@ foldGuess base acc path = (doesDirectoryExist <| combine base path) >>= \case
   False -> return acc
 
 -- | Common build folders for static site generators
+--   Highest -> Lowest priority (reversed because foldM folds from the left)
 buildGuesses :: FilePath -> [FilePath]
-buildGuesses base = map (combine base)
+buildGuesses base = reverse <| map (combine base)
   [ "_site" -- jekyll, hakyll, eleventy
   , "site" -- forgot which
-  , "public" -- gatsby, hugo
+  , "build" -- create-react-app, metalsmith, middleman
   , "dist" -- nuxt
+  , "public" -- gatsby, hugo
   , "output" -- pelican
   , "out" -- hexo
-  , "build" -- create-react-app, metalsmith, middleman
   , "website/build" -- docusaurus
   , "docs" -- many others
   ]

--- a/library/Fission/CLI/Prompt/BuildDir.hs
+++ b/library/Fission/CLI/Prompt/BuildDir.hs
@@ -1,39 +1,59 @@
-module Fission.CLI.Prompt.BuildDir
-  ( checkBuildDir
-  , findBuildDir
-  ) where
+module Fission.CLI.Prompt.BuildDir (checkBuildDir) where
 
 import           Fission.Prelude
 import           RIO.Directory
 import           RIO.FilePath
 
 import           Data.Text as T (pack)
-import qualified System.Console.ANSI as ANSI
+
+import qualified System.Console.ANSI   as ANSI
 import qualified Fission.Internal.UTF8 as UTF8
 
-import qualified Fission.CLI.Prompt           as Prompt
+import qualified Fission.CLI.Prompt      as Prompt
+import qualified Fission.CLI.Environment as Env
+import qualified Fission.CLI.Environment.Partial as Env.Partial
+import           Fission.CLI.Environment.Partial.Types as Env
 
 checkBuildDir ::
-  ( MonadIO m)
-  => FilePath
-  -> m (FilePath)
-checkBuildDir path = findBuildDir path >>= \case
-  Nothing -> return path 
-  Just dir -> do
-    UTF8.putText <| "👷 We found a possible build dir: "
-    liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
-    UTF8.putTextLn <| T.pack dir
-    liftIO <| ANSI.setSGR [ANSI.Reset]
-    resp <- Prompt.reaskYN "❔ Would you like to upload that instead of the project root? (y/n): "
-    case resp of 
-      False -> return path
-      True -> return dir
-
-findBuildDir ::
   ( MonadIO m )
   => FilePath
-  -> m (Maybe FilePath)
-findBuildDir path = foldM (foldGuess path) Nothing (buildGuesses path)
+  -> m FilePath
+checkBuildDir relPath = do
+  absPath <- makeAbsolute relPath
+  findEnv absPath >>= \case
+    Just (envPath, buildDir) ->
+      return <| (takeDirectory envPath) </> buildDir
+    Nothing -> guessBuildDir relPath >>= \case
+      Nothing -> return relPath 
+      Just guess -> do
+        buildDir <- promptBuildDir guess >>= \case
+          True -> return guess
+          False -> return relPath
+        let empty = mempty Env.Partial
+        let updated = empty { maybeBuildDir = Just buildDir }
+        Env.Partial.writeMerge (absPath </> ".fission.yaml") updated
+        return buildDir
+
+findEnv :: ( MonadIO m ) => FilePath -> m (Maybe (FilePath, FilePath))
+findEnv path = Env.findRecurse (isJust . maybeBuildDir) path >>= \case
+  Nothing -> return Nothing
+  Just (envPath, env) -> do
+    case maybeBuildDir env of
+      Nothing -> return Nothing
+      Just buildDir -> return <| Just (envPath, buildDir)
+
+
+promptBuildDir :: ( MonadIO m ) => FilePath -> m Bool
+promptBuildDir path = do
+  UTF8.putText <| "👷 We found a possible build dir: "
+  liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
+  UTF8.putTextLn <| T.pack path
+  liftIO <| ANSI.setSGR [ANSI.Reset]
+  -- \xD83E\xDD14 == 🤔 (will be available in the next version of the parser)
+  Prompt.reaskYN "\xD83E\xDD14 Would you like to upload that instead of the project root? (y/n): "
+
+guessBuildDir :: ( MonadIO m ) => FilePath -> m (Maybe FilePath)
+guessBuildDir path = foldM (foldGuess path) Nothing (buildGuesses path)
 
 foldGuess :: MonadIO m => FilePath -> Maybe FilePath -> FilePath -> m (Maybe FilePath)
 foldGuess base acc path = (doesDirectoryExist <| combine base path) >>= \case

--- a/library/Fission/CLI/Prompt/BuildDir.hs
+++ b/library/Fission/CLI/Prompt/BuildDir.hs
@@ -1,0 +1,54 @@
+module Fission.CLI.Prompt.BuildDir
+  ( checkBuildDir
+  , findBuildDir
+  ) where
+
+import           Fission.Prelude
+import           RIO.Directory
+import           RIO.FilePath
+
+import           Data.Text as T (pack)
+import qualified System.Console.ANSI as ANSI
+import qualified Fission.Internal.UTF8 as UTF8
+
+import qualified Fission.CLI.Prompt           as Prompt
+
+checkBuildDir ::
+  ( MonadIO m)
+  => FilePath
+  -> m (FilePath)
+checkBuildDir path = findBuildDir path >>= \case
+  Nothing -> return path 
+  Just dir -> do
+    UTF8.putText <| "👷 We found a possible build dir: "
+    liftIO <| ANSI.setSGR [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Blue]
+    UTF8.putTextLn <| T.pack dir
+    liftIO <| ANSI.setSGR [ANSI.Reset]
+    resp <- Prompt.reaskYN "❔ Would you like to upload that instead of the project root? (y/n): "
+    case resp of 
+      False -> return path
+      True -> return dir
+
+findBuildDir ::
+  ( MonadIO m )
+  => FilePath
+  -> m (Maybe FilePath)
+findBuildDir path = foldM (foldGuess path) Nothing (buildGuesses path)
+
+foldGuess :: MonadIO m => FilePath -> Maybe FilePath -> FilePath -> m (Maybe FilePath)
+foldGuess base acc path = (doesDirectoryExist <| combine base path) >>= \case
+  True -> return <| Just path
+  False -> return acc
+
+buildGuesses :: FilePath -> [FilePath]
+buildGuesses base = map (combine base)
+  [ "_site" -- jekyll, hakyll, eleventy
+  , "site" -- forgot which
+  , "public" -- gatsby, hugo
+  , "dist" -- nuxt
+  , "output" -- pelican
+  , "out" -- hexo
+  , "build" -- create-react-app, metalsmith, middleman
+  , "website/build" -- docusaurus
+  , "docs" -- many others
+  ]

--- a/library/Fission/CLI/Prompt/BuildDir.hs
+++ b/library/Fission/CLI/Prompt/BuildDir.hs
@@ -33,8 +33,8 @@ checkBuildDir relPath = do
         buildDir <- promptBuildDir guess >>= \case
           True -> return guess
           False -> return relPath
-        let empty = mempty Env.Partial
-        let updated = empty { maybeBuildDir = Just buildDir }
+        let
+          updated = (mempty Env.Partial) { maybeBuildDir = Just buildDir }
         Env.Partial.writeMerge (absPath </> ".fission.yaml") updated
         return buildDir
 


### PR DESCRIPTION
## Problem
The CLI currently watches & syncs the current working directory.
It's inconvenient to have to find your build directory, and a common mistake to invoke `up` or start `watch` from the project root. The expected behaviour is clearly to have the CLI be more project-aware.

## Solution
- Detect common build directories (https://github.com/fission-suite/cli/issues/4#issuecomment-553430192)
- prompt the user to see if they'd rather use the build dir
- make a record of that in the projects `.fission.yaml`, or allow for custom build dirs by setting `build_dir`

Closes https://github.com/fission-suite/cli/issues/4