### PR TITLE
Add the ability to set login username and password via cli options

### DIFF
--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -35,7 +35,7 @@ command :: MonadIO m
 command cfg =
   addCommand
     "login"
-    "Add your Fission! credentials"
+    "Add your Fission credentials"
     (\options -> void <| runRIO cfg <| login options)
     parseOptions
 
@@ -77,10 +77,11 @@ login Login.Options {..} = do
 
 parseOptions :: Parser Login.Options
 parseOptions = do
-  username2 <- strArgument <| mconcat
-    [ metavar "PATH"
-    , help    "The file path of the assetss or directory to sync"
-    , value   "./"
+  username2 <- strOption <| mconcat
+    [ long    "user"
+    , metavar "FISSION_USERNAME"
+    , help    "The username to login with"
+    , value   ""
     ]
 
   return Login.Options {..}

--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -18,6 +18,7 @@ import qualified Fission.CLI.Environment as Environment
 
 import           Fission.CLI.Config.Types
 
+import           Fission.CLI.Command.Login.Types as Login
 import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
@@ -34,16 +35,18 @@ command cfg =
     "login"
     "Add your Fission credentials"
     (const <| runRIO cfg login)
-    (pure ())
+    parseOptions
 
 -- | Login (i.e. save credentials to disk). Validates credentials agianst the server.
 login :: MonadRIO          cfg m
       => MonadUnliftIO         m
       => HasLogFunc        cfg
       => Has Client.Runner cfg
-      => m ()
-login = do
+      => Login.Options ()
+      -> m ()
+login Login.Options {..} = do
   logDebug "Starting login sequence"
+  logDebug username2
   putStr "Username: "
   username <- getLine
   liftIO (runInputT defaultSettings <| getPassword (Just '•') "Password: ") >>= \case
@@ -69,4 +72,16 @@ login = do
 
           Environment.init auth
           CLI.Success.putOk "Registered & logged in. Your credentials are in ~/.fission.yaml"
+
+parseOptions :: Parser Login.Options
+parseOptions = do
+
+  username2 <- strArgument <| mconcat
+    [ metavar "FISSION_USERNAME"
+    , long "username2"
+    , short "u"
+    , help    "Specifcy the FIssion user you'd like to login as"
+    ]
+
+  return Login.Options {..}
 

--- a/library/Fission/CLI/Command/Login/Types.hs
+++ b/library/Fission/CLI/Command/Login/Types.hs
@@ -3,4 +3,4 @@ module Fission.CLI.Command.Login.Types (Options(..)) where
 import Fission.Prelude hiding (Options)
 
 -- | Arguments, flags & switches for the `login` command
-data Options = Options{ username2 :: Text}
+data Options = Options{ username2 :: String }

--- a/library/Fission/CLI/Command/Login/Types.hs
+++ b/library/Fission/CLI/Command/Login/Types.hs
@@ -3,4 +3,4 @@ module Fission.CLI.Command.Login.Types (Options(..)) where
 import Fission.Prelude hiding (Options)
 
 -- | Arguments, flags & switches for the `login` command
-data Options = Options{ username2 :: String }
+data Options = Options{ username_option :: Maybe ByteString }

--- a/library/Fission/CLI/Command/Login/Types.hs
+++ b/library/Fission/CLI/Command/Login/Types.hs
@@ -1,0 +1,6 @@
+module Fission.CLI.Command.Login.Types (Options(..)) where
+
+import Fission.Prelude hiding (Options)
+
+-- | Arguments, flags & switches for the `login` command
+data Options = Options{ username2 :: Text}

--- a/library/Fission/CLI/Command/Login/Types.hs
+++ b/library/Fission/CLI/Command/Login/Types.hs
@@ -3,4 +3,7 @@ module Fission.CLI.Command.Login.Types (Options(..)) where
 import Fission.Prelude hiding (Options)
 
 -- | Arguments, flags & switches for the `login` command
-data Options = Options{ username_option :: Maybe ByteString }
+data Options = Options
+  { username_option :: Maybe ByteString
+  , password_option :: Maybe ByteString
+  }


### PR DESCRIPTION
## Summary
Adds two new flags to `login`. `--username` and `--password` which can be used to set the users credentials when logging in.

This is a first step to allowing fission live to be used from a cli
## Test plan (required)

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on Circle CI. -->

## Notes for Reviewers
@expede after our last conversation. I remember us landing on that we could get this working before the changes to our authentication structure by using flags in our CLI. After those auth changes we can look at how it would be overridden using env variables. 

I wanted to check if that still conversation still holds?

Fixes #

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
