### PR TITLE
Add local flag for login & register

### DIFF
--- a/library/Fission/CLI/Command/Login.hs
+++ b/library/Fission/CLI/Command/Login.hs
@@ -3,6 +3,8 @@ module Fission.CLI.Command.Login (command, login) where
 
 import           Fission.Prelude
 import           RIO.ByteString
+import           RIO.Directory
+import           RIO.FilePath
 
 import qualified Data.ByteString.Char8 as BS
 
@@ -14,7 +16,10 @@ import qualified Fission.Config as Config
 
 import           Fission.Web.Client.User as User.Client
 import qualified Fission.Web.Client.Types as Client
-import qualified Fission.CLI.Environment as Environment
+
+import qualified Fission.CLI.Environment               as Env
+import           Fission.CLI.Environment.Partial.Types as Env
+import qualified Fission.CLI.Environment.Partial       as Env.Partial
 
 import           Fission.CLI.Config.Types
 
@@ -88,8 +93,18 @@ login Login.Options {..} = do
         Right _ok -> do
           logDebug "Auth Successful"
 
-          Environment.init auth
-          CLI.Success.putOk "Registered & logged in. Your credentials are in ~/.fission.yaml"
+          if local_auth
+          then do
+            currDir <- getCurrentDirectory
+            let 
+              envPath    = currDir </> ".fission.yaml"
+              updatedEnv = (mempty Env.Partial) { maybeUserAuth = Just auth }
+            Env.Partial.writeMerge envPath updatedEnv
+            CLI.Success.putOk 
+              <| "Successfully logged in. Your credentials are in " <> textShow envPath
+          else do
+            Env.init auth
+            CLI.Success.putOk "Successfully logged in. Your credentials are in ~/.fission.yaml"
 
 parseOptions :: Parser Login.Options
 parseOptions = do
@@ -103,6 +118,11 @@ parseOptions = do
     [ long    "password"
     , metavar "FISSION_PASSWORD"
     , help    "The password to login with"
+    ]
+
+  local_auth <- switch <| mconcat
+    [ long "local"
+    , help "Login at project root (as opposed to global at user home)"
     ]
 
   return Login.Options {..}

--- a/library/Fission/CLI/Command/Login/Types.hs
+++ b/library/Fission/CLI/Command/Login/Types.hs
@@ -6,4 +6,5 @@ import Fission.Prelude hiding (Options)
 data Options = Options
   { username_option :: Maybe ByteString
   , password_option :: Maybe ByteString
+  , local_auth      :: Bool
   }

--- a/library/Fission/CLI/Command/Register.hs
+++ b/library/Fission/CLI/Command/Register.hs
@@ -3,11 +3,13 @@ module Fission.CLI.Command.Register (command, register) where
 
 import           Fission.Prelude
 import           RIO.ByteString
+import           RIO.Directory
+import           RIO.FilePath
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text as T
 
-import           Options.Applicative.Simple (addCommand)
+import           Options.Applicative.Simple hiding (command)
 import           Servant
 import           System.Console.Haskeline
 
@@ -18,13 +20,17 @@ import qualified Fission.Web.Client.Types as Client
 
 import qualified Fission.User.Registration.Types as User
 
+import qualified Fission.CLI.Environment               as Env
+import           Fission.CLI.Environment.Partial.Types as Env
+import qualified Fission.CLI.Environment.Partial       as Env.Partial
+
 import           Fission.CLI.Config.Types
 
+import           Fission.CLI.Command.Register.Types as Register
 import qualified Fission.CLI.Display.Cursor  as Cursor
 import qualified Fission.CLI.Display.Success as CLI.Success
 import qualified Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Wait    as CLI.Wait
-import qualified Fission.CLI.Environment     as Environment
 
 -- | The command to attach to the CLI tree
 command :: MonadUnliftIO m
@@ -36,28 +42,38 @@ command cfg =
   addCommand
     "register"
     "Register for Fission and login"
-    (const <| runRIO cfg register)
-    (pure ())
+    (\options -> void <| runRIO cfg <| register options)
+    parseOptions
 
 -- | Register and login (i.e. save credentials to disk)
 register :: MonadRIO       cfg m
         => MonadUnliftIO         m
         => HasLogFunc        cfg
         => Has Client.Runner cfg
-        => m ()
-register = Environment.get >>= \case
-  Right _auth ->
-    CLI.Success.putOk "Already registered. Remove your credentials at ~/.fission.yaml if you want to re-register"
-
-  Left _err ->
-    register'
+        => Register.Options
+        -> m ()
+register Register.Options {..} = do
+  envPath <-
+    if local_auth
+    then getCurrentDirectory >>= \dir -> return <| dir </> ".fission.yaml"
+    else Env.Partial.globalEnv
+  
+  env <- Env.Partial.decode envPath
+  case maybeUserAuth env of
+    Nothing -> register' local_auth
+    Just _ -> 
+      CLI.Success.putOk <| mconcat
+        [ "Already registered. Remove your credentials at "
+        ,  textShow envPath 
+        , " if you want to re-register"]
 
 register' :: MonadRIO cfg m
           => MonadUnliftIO         m
           => HasLogFunc        cfg
           => Has Client.Runner cfg
-          => m ()
-register' = do
+          => Bool
+          -> m ()
+register' local_auth = do
   logDebug "Starting registration sequence"
 
   putStr "Username: "
@@ -92,7 +108,28 @@ register' = do
           CLI.Error.put err "Authorization failed"
 
         Right _ok -> do
-          let basicAuth = BasicAuthData username (BS.pack password)
+          logDebug "Register Successful"
 
-          Environment.init basicAuth
-          CLI.Success.putOk "Registered & logged in. Your credentials are in ~/.fission.yaml"
+          let auth = BasicAuthData username (BS.pack password)
+
+          if local_auth
+          then do
+            currDir <- getCurrentDirectory
+            let 
+              envPath    = currDir </> ".fission.yaml"
+              updatedEnv = (mempty Env.Partial) { maybeUserAuth = Just auth }
+            Env.Partial.writeMerge envPath updatedEnv
+            CLI.Success.putOk 
+              <| "Registered & logged in. Your credentials are in " <> textShow envPath
+          else do
+            Env.init auth
+            CLI.Success.putOk "Registered & logged in. Your credentials are in ~/.fission.yaml"
+
+parseOptions :: Parser Register.Options
+parseOptions = do
+  local_auth <- switch <| mconcat
+    [ long "local"
+    , help "Register at project root (as opposed to global at user home)"
+    ]
+
+  return Register.Options {..}

--- a/library/Fission/CLI/Command/Register/Types.hs
+++ b/library/Fission/CLI/Command/Register/Types.hs
@@ -1,0 +1,7 @@
+module Fission.CLI.Command.Register.Types (Options(..)) where
+
+import Fission.Prelude hiding (Options)
+
+-- | Arguments, flags & switches for the `login` command
+data Options = Options
+  { local_auth :: Bool }

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -64,7 +64,7 @@ init auth = do
 
 -- | Gets hierarchical environment by recursing through file system
 get :: MonadIO m => m (Either Error.Env Environment)
-get = do 
+get = do
   partial <- Env.Partial.get
   return <| Env.Partial.toFull partial
 
@@ -72,21 +72,23 @@ get = do
 write :: MonadIO m => FilePath -> Environment -> m ()
 write path env = Env.Partial.write path <| Env.Partial.fromFull env
 
+-- | Get the path to the Environment file, local or global
 getPath :: MonadIO m => Bool -> m FilePath
-getPath True = getCurrentDirectory >>= \dir -> return <| dir </> ".fission.yaml"
-getPath False = globalEnv
+getPath local = if local
+                then  getCurrentDirectory >>= \dir -> return <| dir </> ".fission.yaml"
+                else globalEnv
 
 -- | Locate current auth on the user's system
 findLocalAuth :: MonadIO m => m (Either Error.Env FilePath)
 findLocalAuth = do
   currDir <- getCurrentDirectory
   findRecurse (isJust . maybeUserAuth) currDir >>= \case
-    Nothing -> return <| Left Error.EnvNotFound 
+    Nothing -> return <| Left Error.EnvNotFound
     Just (path, _) -> return <| Right path
 
 -- | Recurses up to user root to find a env that satisfies function "f"
 findRecurse :: MonadIO m => (Env.Partial -> Bool) -> FilePath -> m (Maybe (FilePath, Env.Partial))
-findRecurse f path = do 
+findRecurse f path = do
   let filepath = path </> ".fission.yaml"
   partial <- Env.Partial.decode filepath
   case (f partial, path) of

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -2,6 +2,7 @@
 module Fission.CLI.Environment
   ( init
   , get
+  , getPath
   , findLocalAuth
   , findRecurse
   , couldNotRead
@@ -70,6 +71,10 @@ get = do
 -- | Writes env to path, overwriting if necessary
 write :: MonadIO m => FilePath -> Environment -> m ()
 write path env = Env.Partial.write path <| Env.Partial.fromFull env
+
+getPath :: MonadIO m => Bool -> m FilePath
+getPath True = getCurrentDirectory >>= \dir -> return <| dir </> ".fission.yaml"
+getPath False = globalEnv
 
 -- | Locate current auth on the user's system
 findLocalAuth :: MonadIO m => m (Either Error.Env FilePath)

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: fission-cli
-version: '1.22.0'
+version: '1.23.0'
 category: API
 author:
   - Brooklyn Zelenka


### PR DESCRIPTION
## Problem
Users have to manually create a `.fission.yaml` for project-specific auth

## Solution
Add a `--local` flag for `login` & `register` that stores auth at the current directory instead of in globalEnv