### PR TITLE
Auto detect urls in fission down

### DIFF
--- a/library/Fission/CLI/Command/Down.hs
+++ b/library/Fission/CLI/Command/Down.hs
@@ -3,9 +3,10 @@ module Fission.CLI.Command.Down (command, down) where
 
 import           Fission.Prelude
 import           RIO.Process (HasProcessContext)
-
+import           Network.URI as URI
 import           Options.Applicative.Simple (addCommand)
 import           Options.Applicative (strArgument, metavar, help)
+import qualified Data.Text as Text
 
 import qualified Fission.Storage.IPFS.Get as IPFS
 import qualified Fission.IPFS.Types       as IPFS
@@ -34,22 +35,32 @@ command cfg =
       , help "The CID of the IPFS object you want to download"
       ])
 
+-- | Return an IPNS address if the identifier is a URI
+handleIPNS :: Text -> CID
+handleIPNS identifer = case URI.parseURI (Text.unpack identifer) of
+  Just uri -> do
+    let url = uri |> URI.authority |> Text.pack
+    CID ("/ipns/" <> url)
+  Nothing ->
+    CID identifer
+
 -- | Sync the current working directory to the server over IPFS
 down :: MonadUnliftIO         m
-     => MonadRIO          cfg m
-     => HasLogFunc        cfg
-     => HasProcessContext cfg
-     => Has IPFS.Timeout  cfg
-     => Has IPFS.BinPath  cfg
-     => IPFS.CID
-     -> m ()
-down cid@(CID hash) = do
-  getResult <- CLI.Wait.waitFor "Retrieving Object..." <| 
-                IPFS.getFileOrDirectory cid
+      => MonadRIO          cfg m
+      => HasLogFunc        cfg
+      => HasProcessContext cfg
+      => Has IPFS.Timeout  cfg
+      => Has IPFS.BinPath  cfg
+      => IPFS.CID
+      -> m ()
+down (CID identifer) = do
+  getResult <- CLI.Wait.waitFor "Retrieving Object..."
+              <| IPFS.getFileOrDirectory
+              <| handleIPNS identifer
 
   case getResult of
     Right _ok ->
-      CLI.Success.putOk <| hash <> " Successfully downloaded!"
+      CLI.Success.putOk <| identifer <> " Successfully downloaded!"
 
     Left err ->
       CLI.Error.put err "Oh no! The download failed unexpectedly"

--- a/package.yaml
+++ b/package.yaml
@@ -110,6 +110,7 @@ dependencies:
   - time
   - transformers
   - unliftio
+  - network-uri
   - uuid
   - uuid-types
   - word8


### PR DESCRIPTION
## Summary
`fission down` now can auto detect urls and make the appropriate `ipns` request

Example
```bash
fission down https://ben.runfission.com
```

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
