### PR TITLE
Change RIO_VERBOSE -> Debug

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,7 +19,7 @@ import qualified Fission.CLI.Config.Base.Types as CLI
 
 main :: IO ()
 main = do
-  verbose     <- isJust <$> lookupEnv "RIO_VERBOSE"
+  verbose     <- isJust <$> lookupEnv "DEBUG"
   logOptions  <- logOptionsHandle stderr verbose
   _processCtx <- mkDefaultProcessContext
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -9,6 +9,7 @@ import           Servant.Client
 import           System.Environment (lookupEnv)
 
 import           Fission.Environment
+import           Fission.App (isDebugEnabled, setRioVerbose)
 import qualified Fission.Web.Client as Client
 
 import qualified Fission.IPFS.BinPath.Types as IPFS
@@ -19,8 +20,13 @@ import qualified Fission.CLI.Config.Base.Types as CLI
 
 main :: IO ()
 main = do
-  verbose     <- isJust <$> lookupEnv "DEBUG"
-  logOptions  <- logOptionsHandle stderr verbose
+  isVerbose     <- isDebugEnabled
+
+  -- Set env var RIO_VERBOSE to True if DEBUG enabled
+  setRioVerbose isVerbose
+
+  logOptions  <- logOptionsHandle stderr isVerbose
+
   _processCtx <- mkDefaultProcessContext
 
   _ipfsPath    <- withEnv "IPFS_PATH" (IPFS.BinPath "/usr/local/bin/ipfs") IPFS.BinPath

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-14.6
+resolver: lts-14.14
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,7 @@ extra-deps:
 - tasty-rerun-1.1.14
 - lzma-clib-5.2.2
 - git: https://github.com/fission-suite/web-api.git
-  commit: 931c8bdd3bcde65bcb0daecd6a22c771c75f8f7d
+  commit: dddf53ad55ada2cde00d143d75cc348f4920f3fc
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,7 @@ extra-deps:
 - tasty-rerun-1.1.14
 - lzma-clib-5.2.2
 - git: https://github.com/fission-suite/web-api.git
-  commit: 8968e5ac10c5cd49005bb826a501ae6f0fad1cd2
+  commit: 931c8bdd3bcde65bcb0daecd6a22c771c75f8f7d
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -83,18 +83,18 @@ packages:
     hackage: lzma-clib-5.2.2
 - completed:
     cabal-file:
-      size: 21846
-      sha256: 76ef94c7297c953fc43d74388caa72dec05b28e3c6dd9b580db3bb8183cbd9b0
+      size: 21882
+      sha256: a7fa492cd333afdbf31b7c1b19f856824eb95833fb4f7f7c36f8f02c3fb570e4
     name: fission-web-api
     version: 2.0.1
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
-      size: 12030
-      sha256: b9a33bbea58aeec9faebe726580f9179bc7b6b43aa128cafa7649d4417a4bb04
-    commit: 8968e5ac10c5cd49005bb826a501ae6f0fad1cd2
+      size: 12092
+      sha256: 627fdb18d19043823bd675c3db8d0ac3da1a0acb2f72546a45d5cebfab07475e
+    commit: 931c8bdd3bcde65bcb0daecd6a22c771c75f8f7d
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: 8968e5ac10c5cd49005bb826a501ae6f0fad1cd2
+    commit: 931c8bdd3bcde65bcb0daecd6a22c771c75f8f7d
 snapshots:
 - completed:
     size: 524127

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -90,11 +90,11 @@ packages:
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
       size: 12092
-      sha256: 627fdb18d19043823bd675c3db8d0ac3da1a0acb2f72546a45d5cebfab07475e
-    commit: 931c8bdd3bcde65bcb0daecd6a22c771c75f8f7d
+      sha256: f76143f16ff1a1b7296e879d413b7d5cc4ab6e4d8373b267a22dd00017fd8015
+    commit: dddf53ad55ada2cde00d143d75cc348f4920f3fc
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: 931c8bdd3bcde65bcb0daecd6a22c771c75f8f7d
+    commit: dddf53ad55ada2cde00d143d75cc348f4920f3fc
 snapshots:
 - completed:
     size: 524127


### PR DESCRIPTION
## Summary
Changes the `RIO_VERBOSE` env var to `DEBUG`

## Closing issues
closes https://github.com/fission-suite/web-api/issues/198 

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
