### PR TITLE
Remove Fission Peer Default

### DIFF
--- a/library/Fission/CLI/Config/FissionConnected.hs
+++ b/library/Fission/CLI/Config/FissionConnected.hs
@@ -52,7 +52,7 @@ ensure action = do
             Right _ -> do
               -- All setup and ready to run!
               result <- liftIO <| runRIO FissionConnected {..} action
-              Right <$> return result
+              return <| Right result
 
             Left err -> do
               -- We were unable to connect!

--- a/library/Fission/CLI/Config/FissionConnected.hs
+++ b/library/Fission/CLI/Config/FissionConnected.hs
@@ -42,22 +42,27 @@ ensure action = do
   -- Get our stored user config
   Environment.get >>= \case
     Right config -> do
-      _peer         <- Environment.getOrRetrievePeer config
-      let _userAuth = Environment.userAuth config
-      let _ignoredFiles = Environment.ignored config
+      Environment.getOrRetrievePeer config >>= \case
+        Just _peer -> do
+          let _userAuth     = Environment.userAuth config
+          let _ignoredFiles = Environment.ignored config
 
-      -- Connect the local IPFS node to the Fission network
-      Connect.swarmConnectWithRetry _peer 1 >>= \case
-        Right _ -> do
-          -- All setup and ready to run!
-          result <- liftIO <| runRIO FissionConnected {..} action
-          Right <$> return result
+          -- Connect the local IPFS node to the Fission network
+          Connect.swarmConnectWithRetry _peer 1 >>= \case
+            Right _ -> do
+              -- All setup and ready to run!
+              result <- liftIO <| runRIO FissionConnected {..} action
+              Right <$> return result
 
-        Left err -> do
-          -- We were unable to connect!
-          logError <| displayShow err
-          Connect.couldNotSwarmConnect
-          return <| Left CannotConnect
+            Left err -> do
+              -- We were unable to connect!
+              logError <| displayShow err
+              Connect.couldNotSwarmConnect
+              return <| Left CannotConnect
+
+        Nothing -> do
+          logError "Could not locate the Fission IPFS network"
+          return <| Left PeersNotFound
 
     Left err -> do
       -- We were unable to read the users config

--- a/library/Fission/CLI/Config/FissionConnected/Error/Types.hs
+++ b/library/Fission/CLI/Config/FissionConnected/Error/Types.hs
@@ -5,4 +5,5 @@ import           Fission.Prelude
 data Error
   = NotFissionConnected
   | CannotConnect
+  | PeersNotFound
   deriving (Eq, Show, Exception)

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -128,25 +128,25 @@ getOrRetrievePeer :: MonadRIO          cfg m
                   => HasLogFunc        cfg
                   => Has Client.Runner cfg
                   => Environment
-                  -> m IPFS.Peer
+                  -> m (Maybe IPFS.Peer)
 getOrRetrievePeer config =
   case peers config of
     Just prs -> do
       logDebug "Retrieved Peer from .fission.yaml"
-      return <| head prs
+      return <| Just <| head prs
 
     Nothing ->
       Peers.getPeers >>= \case
         Left err -> do
           logError <| displayShow err
-          logDebug "Unable to retrieve peers from the network, using default address"
-          return <| IPFS.Peer.fission
+          logDebug "Unable to retrieve peers from the network"
+          return Nothing
 
         Right peers -> do
           logDebug "Retrieved Peer from API"
           path <- globalEnv
           write path <| config { peers = Just (NonEmpty.fromList peers) }
-          return <| head <| NonEmpty.fromList peers
+          return <| Just <| head <| NonEmpty.fromList peers
 
 ignoreDefault :: IPFS.Ignored
 ignoreDefault =

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -34,7 +34,6 @@ import qualified Fission.CLI.Environment.Error as Error
 import           Fission.Internal.Orphanage.BasicAuthData ()
 import qualified Fission.Internal.UTF8 as UTF8
 
-import qualified Fission.IPFS.Peer  as IPFS.Peer
 import qualified Fission.IPFS.Types as IPFS
 
 -- | Initialize the Environment file
@@ -142,11 +141,15 @@ getOrRetrievePeer config =
           logDebug "Unable to retrieve peers from the network"
           return Nothing
 
-        Right peers -> do
+        Right [] -> do
+          logDebug "Network request was successful, but response contained no peers"
+          return Nothing
+
+        Right peers@(peer : _) -> do
           logDebug "Retrieved Peer from API"
           path <- globalEnv
           write path <| config { peers = Just (NonEmpty.fromList peers) }
-          return <| Just <| head <| NonEmpty.fromList peers
+          return <| Just peer
 
 ignoreDefault :: IPFS.Ignored
 ignoreDefault =

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,7 @@ extra-deps:
 - tasty-rerun-1.1.14
 - lzma-clib-5.2.2
 - git: https://github.com/fission-suite/web-api.git
-  commit: a14ecb356ea5475d99307a1a7347b3253c874e6e
+  commit: 8968e5ac10c5cd49005bb826a501ae6f0fad1cd2
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -83,21 +83,21 @@ packages:
     hackage: lzma-clib-5.2.2
 - completed:
     cabal-file:
-      size: 21870
-      sha256: cabe00c1ebf4f7297584fab7a2e26062f9418979c77622fe8df12ba4bb42ddc9
+      size: 21846
+      sha256: 76ef94c7297c953fc43d74388caa72dec05b28e3c6dd9b580db3bb8183cbd9b0
     name: fission-web-api
-    version: 2.0.0
+    version: 2.0.1
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
-      size: 11955
-      sha256: 9eebddd7ab7de52786b8bc2cf3013dddc9b724ef30cc520df72dbd0ff2defc32
-    commit: ce4df3b37e63bd37a979221e52b8c334c105c27a
+      size: 12030
+      sha256: b9a33bbea58aeec9faebe726580f9179bc7b6b43aa128cafa7649d4417a4bb04
+    commit: 8968e5ac10c5cd49005bb826a501ae6f0fad1cd2
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: ce4df3b37e63bd37a979221e52b8c334c105c27a
+    commit: 8968e5ac10c5cd49005bb826a501ae6f0fad1cd2
 snapshots:
 - completed:
-    size: 525663
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/14.yaml
-    sha256: 6edc48df46eb8bf7b861e98dd30d021a92c2e1820c9bb6528aac5d997b0e14ef
-  original: lts-14.14
+    size: 524127
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/6.yaml
+    sha256: dc70dfb45e2c32f54719819bd055f46855dd4b3bd2e58b9f3f38729a2d553fbb
+  original: lts-14.6


### PR DESCRIPTION

## Summary
This PR updates the CLI to work with latest `web-api` as a result it must remove the use of the Peer default.

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
