### PR TITLE
Ipfs refactor

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,8 +11,8 @@ import           Fission.Environment
 import           Fission.App (isDebugEnabled, setRioVerbose)
 import qualified Fission.Web.Client as Client
 
-import qualified Fission.IPFS.BinPath.Types as IPFS
-import qualified Fission.IPFS.Timeout.Types as IPFS
+import qualified Network.IPFS.BinPath.Types as IPFS
+import qualified Network.IPFS.Timeout.Types as IPFS
 
 import           Fission.CLI
 import qualified Fission.CLI.Config.Base.Types as CLI

--- a/library/Fission/CLI.hs
+++ b/library/Fission/CLI.hs
@@ -6,7 +6,8 @@ import           RIO.Process (HasProcessContext)
 import           Options.Applicative.Simple
 
 import qualified Fission.Web.Client   as Client
-import qualified Fission.IPFS.Types   as IPFS
+
+import qualified Network.IPFS.Types   as IPFS
 
 import qualified Fission.CLI.Command.Login         as Login
 import qualified Fission.CLI.Command.Logout        as Logout
@@ -18,14 +19,16 @@ import qualified Fission.CLI.Command.Watch         as Watch
 import qualified Fission.CLI.Command.Whoami        as Whoami
 
 -- | Top-level CLI description
-cli :: MonadRIO    cfg m
-    => MonadUnliftIO m
-    => HasLogFunc        cfg
-    => HasProcessContext cfg
-    => Has Client.Runner cfg
-    => Has IPFS.BinPath  cfg
-    => Has IPFS.Timeout  cfg
-    => m ()
+cli ::
+  ( MonadRIO    cfg m
+  , MonadUnliftIO m
+  , HasLogFunc        cfg
+  , HasProcessContext cfg
+  , Has Client.Runner cfg
+  , Has IPFS.BinPath  cfg
+  , Has IPFS.Timeout  cfg
+  )
+  => m ()
 cli = do
   cfg <- ask
   (_, runCLI) <- liftIO <| simpleOptions version description detail (pure ()) do

--- a/library/Fission/CLI/Config/Base/Types.hs
+++ b/library/Fission/CLI/Config/Base/Types.hs
@@ -13,7 +13,7 @@ import Fission.Prelude
 import Control.Lens (makeLenses)
 
 import qualified Fission.Web.Client.Types as Client
-import qualified Fission.IPFS.Types       as IPFS
+import qualified Network.IPFS.Types       as IPFS
 
 -- | The configuration used for the CLI application
 data BaseConfig = BaseConfig

--- a/library/Fission/CLI/Config/FissionConnected.hs
+++ b/library/Fission/CLI/Config/FissionConnected.hs
@@ -7,7 +7,9 @@ module Fission.CLI.Config.FissionConnected
 import           Fission.Prelude
 import           RIO.Process (ProcessContext, HasProcessContext (..))
 
-import qualified Fission.IPFS.Types   as IPFS
+import           Network.IPFS
+import qualified Network.IPFS.Types   as IPFS
+
 import qualified Fission.Web.Client   as Client
 
 import qualified Fission.Config as Config
@@ -22,14 +24,15 @@ import qualified Fission.CLI.IPFS.Connect      as Connect
 --
 -- Takes a @FissionConnected@-dependant action, and lifts it into an environment that
 -- contains a superset of the environment
-ensure
-  :: ( MonadRIO          cfg m
-     , HasLogFunc        cfg
-     , HasProcessContext cfg
-     , Has IPFS.BinPath  cfg
-     , Has IPFS.Timeout  cfg
-     , Has Client.Runner cfg
-     )
+ensure ::
+  ( MonadRIO          cfg m
+  , MonadLocalIPFS m
+  , HasLogFunc        cfg
+  , HasProcessContext cfg
+  , Has IPFS.BinPath  cfg
+  , Has IPFS.Timeout  cfg
+  , Has Client.Runner cfg
+  )
   => RIO FissionConnected a
   -> m (Either Error a)
 ensure action = do

--- a/library/Fission/CLI/Config/FissionConnected/Types.hs
+++ b/library/Fission/CLI/Config/FissionConnected/Types.hs
@@ -17,7 +17,7 @@ import Servant.API
 import Control.Lens (makeLenses)
 
 import qualified Fission.Web.Client.Types as Client
-import qualified Fission.IPFS.Types       as IPFS
+import qualified Network.IPFS.Types       as IPFS
 
 
 type HasFissionConnected cfg

--- a/library/Fission/CLI/DNS.hs
+++ b/library/Fission/CLI/DNS.hs
@@ -7,7 +7,6 @@ import Servant
 import Servant.Client
 
 import qualified Fission.Config as Config
-import           Fission.IPFS.CID.Types
 
 import qualified Fission.Web.Client      as Client
 import qualified Fission.Web.DNS.Client  as DNS.Client
@@ -16,14 +15,17 @@ import           Fission.CLI.Display.Error   as CLI.Error
 import qualified Fission.CLI.Display.Loader  as CLI
 import           Fission.CLI.Display.Success as CLI.Success
 
+import           Network.IPFS.CID.Types
 import qualified Fission.AWS.Types as AWS
 
-update :: MonadRIO       cfg m
-    => HasLogFunc        cfg
-    => Has Client.Runner cfg
-    => Has BasicAuthData cfg
-    => CID
-    -> m (Either ClientError AWS.DomainName)
+update ::
+  ( MonadRIO       cfg m
+  , HasLogFunc        cfg
+  , Has Client.Runner cfg
+  , Has BasicAuthData cfg
+  )
+  => CID
+  -> m (Either ClientError AWS.DomainName)
 update cid@(CID hash) = do
   auth <- Config.get
   logDebug <| "Updating DNS to " <> display hash

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -13,6 +13,7 @@ module Fission.CLI.Environment
 import           Fission.Prelude
 import           RIO.Directory
 import           RIO.FilePath
+
 import           Servant.API
 
 import qualified System.FilePath.Glob as Glob
@@ -34,7 +35,7 @@ import qualified Fission.CLI.Environment.Error as Error
 import           Fission.Internal.Orphanage.BasicAuthData ()
 import qualified Fission.Internal.UTF8 as UTF8
 
-import qualified Fission.IPFS.Types as IPFS
+import qualified Network.IPFS.Types as IPFS
 
 -- | Initialize the Environment file
 init :: MonadRIO cfg m

--- a/library/Fission/CLI/Environment/Partial.hs
+++ b/library/Fission/CLI/Environment/Partial.hs
@@ -23,7 +23,7 @@ import qualified Fission.CLI.Environment.Error as Error
 
 import           Fission.Internal.Orphanage.BasicAuthData ()
 
-import qualified Fission.IPFS.Types as IPFS
+import qualified Network.IPFS.Types as IPFS
 
 -- | Gets hierarchical environment by recursed through file system
 get :: MonadIO m => m Env.Partial

--- a/library/Fission/CLI/Environment/Partial/Types.hs
+++ b/library/Fission/CLI/Environment/Partial/Types.hs
@@ -4,7 +4,7 @@ import Fission.Prelude
 
 import           Servant.API
 
-import qualified Fission.IPFS.Types as IPFS
+import qualified Network.IPFS.Types as IPFS
 import           Fission.Internal.Orphanage.BasicAuthData ()
 import           Fission.Internal.Orphanage.Glob.Pattern ()
 

--- a/library/Fission/CLI/Environment/Types.hs
+++ b/library/Fission/CLI/Environment/Types.hs
@@ -4,7 +4,7 @@ import Fission.Prelude
 
 import           Servant.API
 
-import qualified Fission.IPFS.Types as IPFS
+import qualified Network.IPFS.Types as IPFS
 import           Fission.Internal.Orphanage.BasicAuthData ()
 import           Fission.Internal.Orphanage.Glob.Pattern ()
 

--- a/library/Fission/CLI/IPFS/Connect.hs
+++ b/library/Fission/CLI/IPFS/Connect.hs
@@ -18,20 +18,24 @@ import qualified Fission.Internal.UTF8 as UTF8
 
 import           Fission.CLI.IPFS.Error.Types
 
-import qualified Fission.IPFS.Peer  as IPFS.Peer
-import qualified Fission.IPFS.Types as IPFS
+import           Network.IPFS
+import qualified Network.IPFS.Peer  as IPFS.Peer
+import qualified Network.IPFS.Types as IPFS
 
 
 -- | Connect to the Fission IPFS network with a set amount of retries
-swarmConnectWithRetry :: MonadRIO cfg m
-          => HasLogFunc        cfg
-          => HasProcessContext        cfg
-          => Has Client.Runner cfg
-          => Has IPFS.Timeout cfg
-          => Has IPFS.BinPath cfg
-          => IPFS.Peer
-          -> Int
-          -> m (Either SomeException ())
+swarmConnectWithRetry ::
+  ( MonadRIO cfg m
+  , MonadLocalIPFS m
+  , HasLogFunc        cfg
+  , HasProcessContext        cfg
+  , Has Client.Runner cfg
+  , Has IPFS.Timeout cfg
+  , Has IPFS.BinPath cfg
+  )
+  => IPFS.Peer
+  -> Int
+  -> m (Either SomeException ())
 swarmConnectWithRetry _peer (-1) = return <| Left <| toException UnableToConnect
 swarmConnectWithRetry peer tries = IPFS.Peer.connect peer >>= \case
   Right _ ->

--- a/library/Fission/CLI/IPFS/Pin.hs
+++ b/library/Fission/CLI/IPFS/Pin.hs
@@ -11,7 +11,7 @@ import Servant.Client
 
 import qualified Fission.Config as Config
 
-import           Fission.IPFS.CID.Types
+import           Network.IPFS.CID.Types
 
 import qualified Fission.Web.Client      as Client
 import qualified Fission.Web.Client.IPFS as Fission
@@ -21,10 +21,10 @@ import qualified Fission.CLI.Display.Loader  as CLI
 import           Fission.CLI.Display.Success as CLI.Success
 import           Fission.CLI.Config.FissionConnected.Types
 
-run
-  :: ( MonadRIO             cfg m
-     , HasFissionConnected  cfg
-     )
+run ::
+  ( MonadRIO             cfg m
+  , HasFissionConnected  cfg
+  )
   => CID
   -> m (Either ClientError CID)
 run cid@(CID hash)  = do

--- a/library/Fission/Internal/Orphanage/RIO.hs
+++ b/library/Fission/Internal/Orphanage/RIO.hs
@@ -1,0 +1,38 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Fission.Internal.Orphanage.RIO () where
+
+import Fission.Prelude
+
+import RIO.Orphans ()
+
+import qualified RIO.ByteString.Lazy as Lazy
+
+import qualified Fission.Config        as Config
+
+import           Network.IPFS
+import           Network.IPFS.Types         as IPFS
+import qualified Network.IPFS.Process.Error as Process
+import           Network.IPFS.Process
+
+instance 
+  ( HasProcessContext cfg
+  , HasLogFunc cfg
+  , Has IPFS.BinPath cfg
+  , Has IPFS.Timeout cfg
+  )
+  => MonadLocalIPFS (RIO cfg) where
+    runLocal opts arg = do
+      IPFS.BinPath ipfs <- Config.get
+      IPFS.Timeout secs <- Config.get
+      let opts' = ("--timeout=" <> show secs <> "s") : opts
+
+      runProc readProcess ipfs (byteStringInput arg) byteStringOutput opts' >>= \case
+        (ExitSuccess, contents, _) ->
+          return <| Right contents
+        (ExitFailure _, _, stdErr)
+          | Lazy.isSuffixOf "context deadline exceeded" stdErr -> 
+              return . Left <| Process.Timeout secs
+          | otherwise ->
+            return . Left <| Process.UnknownErr stdErr

--- a/library/Fission/Web/Client.hs
+++ b/library/Fission/Web/Client.hs
@@ -11,11 +11,13 @@ import           Servant
 import           Servant.Client
 import           Fission.Web.Client.Types
 
-withAuth :: HasClient ClientM api
-         => Client ClientM api ~ (BasicAuthData -> clients)
-         => BasicAuthData
-         -> Proxy api
-         -> clients
+withAuth ::
+  ( HasClient ClientM api
+  , Client ClientM api ~ (BasicAuthData -> clients)
+  )
+  => BasicAuthData
+  -> Proxy api
+  -> clients
 withAuth basicAuth proxy = client proxy basicAuth
 
 request :: HTTP.Manager -> BaseUrl -> ClientM a -> IO (Either ClientError a)

--- a/library/Fission/Web/Client/IPFS.hs
+++ b/library/Fission/Web/Client/IPFS.hs
@@ -10,8 +10,8 @@ import Fission.Prelude
 import Servant
 import Servant.Client
 
-import qualified Fission.File.Types as File
-import           Fission.IPFS.CID.Types
+import qualified Network.IPFS.File.Types as File
+import           Network.IPFS.CID.Types
 
 import qualified Fission.Web.Client as Client
 import           Fission.Web.Routes (IPFSPrefix)

--- a/library/Fission/Web/Client/Peers.hs
+++ b/library/Fission/Web/Client/Peers.hs
@@ -9,7 +9,7 @@ import Servant.Client
 import qualified Fission.Web.IPFS.Peer as Peer
 import qualified Fission.Web.Client.Types as Client
 
-import qualified Fission.IPFS.Types as IPFS
+import qualified Network.IPFS.Types as IPFS
 
 import qualified Fission.Config as Config
 

--- a/package.yaml
+++ b/package.yaml
@@ -92,6 +92,8 @@ dependencies:
   - haskeline
   - http-client
   - http-client-tls
+  - http-types
+  - ipfs
   - lens
   - monad-logger
   - mtl
@@ -105,6 +107,7 @@ dependencies:
   - scientific
   - servant
   - servant-client
+  - servant-client-core
   - servant-server
   - text
   - time

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,9 @@ extra-deps:
 - tasty-rerun-1.1.14
 - lzma-clib-5.2.2
 - git: https://github.com/fission-suite/web-api.git
-  commit: dddf53ad55ada2cde00d143d75cc348f4920f3fc
+  commit: 9b62ad6e806b30661280857685db215e68d72507
+- git: https://github.com/fission-suite/ipfs-haskell.git
+  commit: 2f704442f92eca6520e28e60ec1c85e23a387400
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -83,18 +83,32 @@ packages:
     hackage: lzma-clib-5.2.2
 - completed:
     cabal-file:
-      size: 21882
-      sha256: a7fa492cd333afdbf31b7c1b19f856824eb95833fb4f7f7c36f8f02c3fb570e4
+      size: 19952
+      sha256: 940ea7c6e5e260a4d648d915e0245f89562fcf1b1b10f18896ef2903c2d89ac0
     name: fission-web-api
     version: 2.0.1
     git: https://github.com/fission-suite/web-api.git
     pantry-tree:
-      size: 12092
-      sha256: f76143f16ff1a1b7296e879d413b7d5cc4ab6e4d8373b267a22dd00017fd8015
-    commit: dddf53ad55ada2cde00d143d75cc348f4920f3fc
+      size: 9631
+      sha256: 97583ba1870b30505778c6fe1e0d0d9215ed34ac5581ae91bde5c7ca30f96173
+    commit: 9b62ad6e806b30661280857685db215e68d72507
   original:
     git: https://github.com/fission-suite/web-api.git
-    commit: dddf53ad55ada2cde00d143d75cc348f4920f3fc
+    commit: 9b62ad6e806b30661280857685db215e68d72507
+- completed:
+    cabal-file:
+      size: 5025
+      sha256: c41389ecbce8472cacebe180f29b572013013a76e7adead1505bad377e769ed7
+    name: ipfs
+    version: 1.0.0
+    git: https://github.com/fission-suite/ipfs-haskell.git
+    pantry-tree:
+      size: 4662
+      sha256: 360de0ebb61340ee6b6cce63e667f0f7ec5b99a3cb9ba479b54cd79e95682bb2
+    commit: 2f704442f92eca6520e28e60ec1c85e23a387400
+  original:
+    git: https://github.com/fission-suite/ipfs-haskell.git
+    commit: 2f704442f92eca6520e28e60ec1c85e23a387400
 snapshots:
 - completed:
     size: 525663


### PR DESCRIPTION
## Problem
CLI isn't using the new [ipfs-haskell](https://github.com/fission-suite/ipfs-haskell) library.

## Solution
Import `ipfs-haskell`, create a local instance for the `MonadLocalIPFS` class, and use switch out the implementation of ipfs-enabled functions to use the library.

_Note: we need to create `newtype`s for both the cli and the web-api to eliminate RIO orphans_