### PR TITLE
fix warnings from compiiler

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,6 @@ import qualified RIO.Partial as Partial
 import           Network.HTTP.Client     as HTTP
 import           Network.HTTP.Client.TLS as HTTP
 import           Servant.Client
-import           System.Environment (lookupEnv)
 
 import           Fission.Environment
 import           Fission.App (isDebugEnabled, setRioVerbose)

--- a/library/Fission/CLI/Environment.hs
+++ b/library/Fission/CLI/Environment.hs
@@ -73,9 +73,10 @@ write path env = Env.Partial.write path <| Env.Partial.fromFull env
 
 -- | Get the path to the Environment file, local or global
 getPath :: MonadIO m => Bool -> m FilePath
-getPath local = if local
-                then  getCurrentDirectory >>= \dir -> return <| dir </> ".fission.yaml"
-                else globalEnv
+getPath ofLocal =
+  if ofLocal
+  then  getCurrentDirectory >>= \dir -> return <| dir </> ".fission.yaml"
+  else globalEnv
 
 -- | Locate current auth on the user's system
 findLocalAuth :: MonadIO m => m (Either Error.Env FilePath)

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -97,7 +97,7 @@ packages:
     commit: dddf53ad55ada2cde00d143d75cc348f4920f3fc
 snapshots:
 - completed:
-    size: 524127
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/6.yaml
-    sha256: dc70dfb45e2c32f54719819bd055f46855dd4b3bd2e58b9f3f38729a2d553fbb
-  original: lts-14.6
+    size: 525663
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/14.yaml
+    sha256: 6edc48df46eb8bf7b861e98dd30d021a92c2e1820c9bb6528aac5d997b0e14ef
+  original: lts-14.14


### PR DESCRIPTION
## Problem
Warnings from compiler on a few different things:
- unused import in `app/Main.hs`
- `URI.authority` is out of date
- `local` var shadows a binding from `Fission.Prelude` in `Environment`

## Solution
- remove unused import
- use new `URI.uriAuthority` fn
- change var name to `ofLocal`