### PR TITLE
Update windows pipeline to use copy files

### DIFF
--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -43,19 +43,14 @@ jobs:
         # Remove the stack lock file due to a compilation issue with git dependencies
         # where Windows changes the line ending and thus modifies the sha256.
         mv stack.yaml.lock hold
-        stack --no-terminal --install-ghc build --copy-bins --local-bin-path $(Build.BinariesDirectory)
+        stack --no-terminal --install-ghc build --copy-bins --local-bin-path $(pwd)
       displayName: Build Dependencies
 
     - task: CopyFiles@2
       inputs:
-        sourceFolder: '$(Build.BinariesDirectory)'
-        contents: '*'
+        sourceFolder: '$(Build.SourcesDirectory)'
+        contents: 'fission-cli-exe.exe'
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
-
-    - task: PublishBuildArtifacts@1
-      inputs:
-        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-        artifactName: drop
 
     - bash: |
         export PATH=$HOME/.local/bin:$PATH
@@ -68,12 +63,6 @@ jobs:
         tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT
         tar -czf .azure-cache/stack-work.tar.gz .stack-work
       displayName: "Pack cache"
-
-    # - task: ArchiveFiles@2
-    #   inputs:
-    #     rootFolderOrFile: $(Build.BinariesDirectory)/
-    #     includeRootFolder: false
-    #     archiveFile: '$(Build.ArtifactStagingDirectory)/${{ parameters.vmImage }}.zip'
 
     - task: PublishPipelineArtifact@1
       inputs:

--- a/.azure/azure-windows-template.yml
+++ b/.azure/azure-windows-template.yml
@@ -46,6 +46,17 @@ jobs:
         stack --no-terminal --install-ghc build --copy-bins --local-bin-path $(Build.BinariesDirectory)
       displayName: Build Dependencies
 
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Build.BinariesDirectory)'
+        contents: '*'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: drop
+
     - bash: |
         export PATH=$HOME/.local/bin:$PATH
         stack test
@@ -58,11 +69,11 @@ jobs:
         tar -czf .azure-cache/stack-work.tar.gz .stack-work
       displayName: "Pack cache"
 
-    - task: ArchiveFiles@2
-      inputs:
-        rootFolderOrFile: $(Build.BinariesDirectory)
-        includeRootFolder: false
-        archiveFile: '$(Build.ArtifactStagingDirectory)/${{ parameters.vmImage }}.zip'
+    # - task: ArchiveFiles@2
+    #   inputs:
+    #     rootFolderOrFile: $(Build.BinariesDirectory)/
+    #     includeRootFolder: false
+    #     archiveFile: '$(Build.ArtifactStagingDirectory)/${{ parameters.vmImage }}.zip'
 
     - task: PublishPipelineArtifact@1
       inputs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-14.14
+resolver: lts-14.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
## Summary
WIndows is outputing an empty zip file instead of one containing the built binary. This should solve that

This also downgrades our stack snapshot from 14.14 to 14.6 due to an issue causing linux 16.4 to fail.

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
